### PR TITLE
FIX: Scale desync when resizing image

### DIFF
--- a/components/canvas/layers/MainImageLayer.tsx
+++ b/components/canvas/layers/MainImageLayer.tsx
@@ -105,20 +105,18 @@ export function MainImageLayer({
           const scaleX = node.scaleX();
           const scaleY = node.scaleY();
 
-          // Use the average of scaleX and scaleY to maintain aspect ratio
           const finalScale = (scaleX + scaleY) / 2;
 
-          // Calculate the new scale based on current screenshot.scale
-          const newScreenshotScale = screenshot.scale * finalScale;
+          const rawNewScale = imageScale * finalScale;
 
-          // Update screenshot scale
-          setScreenshot({ scale: newScreenshotScale });
+          // Round to nearest integer and clamp between 10 and 200
+          const newImageScale = Math.min(Math.max(Math.round(rawNewScale), 10), 200);
 
-          // Update imageScale in the store (imageScale is in percentage, screenshot.scale is decimal)
-          const newImageScale = imageScale * finalScale;
           setImageScale(newImageScale);
 
-          // Reset the node's scale to 1 so transformations don't compound
+          setScreenshot({ scale: newImageScale / 100 });
+
+          // Reset the node's scale to 1 so that the image won't jump on re-render.
           node.scaleX(1);
           node.scaleY(1);
         }}


### PR DESCRIPTION
This PR fixes #35 

this problem is solved by rounding off the scale returned by konva before updating the state.

```typescript
const newImageScale = Math.min(Math.max(Math.round(rawNewScale), 10), 200);
```