### PR TITLE
Fix (canvas): Allow deleting overlays with Delete/Backspace keys

### DIFF
--- a/components/canvas/ClientCanvas.tsx
+++ b/components/canvas/ClientCanvas.tsx
@@ -48,6 +48,7 @@ function CanvasRenderer({ image }: { image: HTMLImageElement }) {
     mockups,
     updateTextOverlay,
     updateImageOverlay,
+    removeImageOverlay,
   } = useImageStore();
 
   const hasMockups = mockups.length > 0 && mockups.some((m) => m.isVisible);
@@ -82,6 +83,20 @@ function CanvasRenderer({ image }: { image: HTMLImageElement }) {
     containerHeight
   );
   const loadedOverlayImages = useOverlayImages(imageOverlays);
+
+  useEffect(() => {                                           // deleting overlays when backspace or delete is pressed
+    const handleKeyDown = (e: KeyboardEvent) => {            
+      if (e.key == 'Delete' || e.key == 'Backspace'){ 
+        if (selectedOverlayId){
+          e.preventDefault()
+          removeImageOverlay(selectedOverlayId);
+          setSelectedOverlayId(null);
+        }
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  },[selectedOverlayId, removeImageOverlay])
 
   useEffect(() => {
     const updateStage = () => {


### PR DESCRIPTION
## Description
Currently, when a user adds an arrow or image overlay, there is no way to remove it via the UI. This PR adds a keyboard event listener to the 'ClientCanvas'.

When an overlay is selected, pressing 'Delete' or 'Backspace' now triggers 'removeImageOverlay', which removes the item from the canvas.

## Type of Change
- [x] Bug fix
- [ ] New feature

## Testing
- [x] Tested manually
- [x] TypeScript compiles without errors
- [x] No console errors

**Steps to test:**
1. Add an arrow or image overlay.
2. Click to select it (ensure blue box appears).
3. Press "Delete" or "Backspace".
4. Confirmed the overlay is removed.