### PR TITLE
feat: add mouse wheel input support for slider controls

### DIFF
--- a/components/controls/BackgroundEffects.tsx
+++ b/components/controls/BackgroundEffects.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { useImageStore } from '@/lib/store';
 import { Slider } from '@/components/ui/slider';
 import { Label } from '@/components/ui/label';
+import { useWheelInput } from '@/hooks/useWheelInput';
 
 export function BackgroundEffects() {
   const {
@@ -12,13 +13,30 @@ export function BackgroundEffects() {
     setBackgroundBlur,
     setBackgroundNoise,
   } = useImageStore();
+  
+  const { ref: blurRef } = useWheelInput({
+    value: backgroundBlur,
+    onChange: setBackgroundBlur,
+    min: 0,
+    max: 50,
+    step: 1,
+  });
+  
+  const { ref: noiseRef } = useWheelInput({
+    value: backgroundNoise,
+    onChange: setBackgroundNoise,
+    min: 0,
+    max: 100,
+    step: 1,
+  });
+
 
   return (
     <div className="space-y-4">
       <h4 className="text-xs font-semibold text-foreground uppercase tracking-wide">Background Effects</h4>
       
       {/* Blur */}
-      <div className="space-y-3">
+      <div ref={blurRef} className="space-y-3">
         <div className="flex justify-between items-center">
           <Label className="text-xs font-medium text-muted-foreground">Blur</Label>
           <span className="text-xs text-muted-foreground font-medium">
@@ -36,7 +54,7 @@ export function BackgroundEffects() {
       </div>
 
       {/* Noise */}
-      <div className="space-y-3">
+      <div ref={noiseRef} className="space-y-3">
         <div className="flex justify-between items-center">
           <Label className="text-xs font-medium text-muted-foreground">Noise</Label>
           <span className="text-xs text-muted-foreground font-medium">

--- a/components/controls/BorderControls.tsx
+++ b/components/controls/BorderControls.tsx
@@ -10,6 +10,8 @@ import { Input } from '@/components/ui/input'
 
 import { useState, useEffect } from 'react'
 
+import { useWheelInput } from '@/hooks/useWheelInput'
+
 const isValidHex = (color: string) => /^#[0-9A-F]{6}$/i.test(color)
 
 function ColorInput({
@@ -315,6 +317,22 @@ export function BorderControls() {
     return imageBorder.type === value
 
   }
+  
+  const { ref: widthRef } = useWheelInput({
+    value: imageBorder.width,
+    onChange: (val) => setImageBorder({ width: val }),
+    min: 1,
+    max: 50,
+    step: 0.5,
+  });
+  
+  const { ref: paddingRef } = useWheelInput({
+    value: imageBorder.padding || 20,
+    onChange: (val) => setImageBorder({ padding: val }),
+    min: 0,
+    max: 100,
+    step: 1,
+  });
 
   return (
     <div className="space-y-4">
@@ -397,7 +415,7 @@ export function BorderControls() {
 
         {['solid', 'glassy', 'dotted', 'eclipse', 'ruler', 'focus'].includes(imageBorder.type) && (
 
-          <div className="p-3 rounded-lg bg-muted/50 border border-border/50">
+          <div ref={widthRef} className="p-3 rounded-lg bg-muted/50 border border-border/50">
             <Slider
               value={[imageBorder.width]}
               onValueChange={([value]) => setImageBorder({ width: value })}
@@ -431,7 +449,7 @@ export function BorderControls() {
 
             </div>
 
-            <div className="p-3 rounded-lg bg-muted/50 border border-border/50">
+            <div ref={paddingRef} className="p-3 rounded-lg bg-muted/50 border border-border/50">
               <Slider
                 value={[imageBorder.padding || 20]}
                 onValueChange={([value]) => setImageBorder({ padding: value })}

--- a/components/controls/Perspective3DControls.tsx
+++ b/components/controls/Perspective3DControls.tsx
@@ -7,6 +7,7 @@ import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { ShadowControls } from '@/components/controls/ShadowControls';
+import { useWheelInput } from '@/hooks/useWheelInput';
 
 interface TransformPreset {
   name: string;
@@ -278,6 +279,55 @@ export function Perspective3DControls() {
       perspective: `${preset.values.perspective}px`,
     };
   };
+  
+  const { ref: perspectiveRef } = useWheelInput({
+    value: perspective3D.perspective,
+    onChange: (val) => setPerspective3D({ perspective: val }),
+    min: 50,
+    max: 1000,
+    step: 10,
+  });
+  
+  const { ref: rotateXRef } = useWheelInput({
+    value: perspective3D.rotateX,
+    onChange: (val) => setPerspective3D({ rotateX: val }),
+    min: -45,
+    max: 45,
+    step: 1,
+  });
+  
+  const { ref: rotateYRef } = useWheelInput({
+    value: perspective3D.rotateY,
+    onChange: (val) => setPerspective3D({ rotateY: val }),
+    min: -45,
+    max: 45,
+    step: 1,
+  });
+  
+  const { ref: rotateZRef } = useWheelInput({
+    value: perspective3D.rotateZ,
+    onChange: (val) => setPerspective3D({ rotateZ: val }),
+    min: -45,
+    max: 45,
+    step: 1,
+  });
+  
+  const { ref: translateXRef } = useWheelInput({
+    value: perspective3D.translateX,
+    onChange: (val) => setPerspective3D({ translateX: val }),
+    min: -10,
+    max: 10,
+    step: 0.5,
+  });
+  
+  const { ref: translateYRef } = useWheelInput({
+    value: perspective3D.translateY,
+    onChange: (val) => setPerspective3D({ translateY: val }),
+    min: -10,
+    max: 10,
+    step: 0.5,
+  });
+
 
   return (
     <div className="space-y-6">
@@ -321,7 +371,7 @@ export function Perspective3DControls() {
       {/* Sliders */}
       <div className="space-y-4">
         {/* Perspective */}
-        <div className="p-3 rounded-lg bg-muted/50 border border-border/50">
+        <div ref={perspectiveRef} className="p-3 rounded-lg bg-muted/50 border border-border/50">
           <Slider
             value={[perspective3D.perspective]}
             onValueChange={(value) => setPerspective3D({ perspective: value[0] })}
@@ -334,7 +384,7 @@ export function Perspective3DControls() {
         </div>
 
         {/* Rotate X */}
-        <div className="p-3 rounded-lg bg-muted/50 border border-border/50">
+        <div ref={rotateXRef} className="p-3 rounded-lg bg-muted/50 border border-border/50">
           <Slider
             value={[perspective3D.rotateX]}
             onValueChange={(value) => setPerspective3D({ rotateX: value[0] })}
@@ -347,7 +397,7 @@ export function Perspective3DControls() {
         </div>
 
         {/* Rotate Y */}
-        <div className="p-3 rounded-lg bg-muted/50 border border-border/50">
+        <div ref={rotateYRef} className="p-3 rounded-lg bg-muted/50 border border-border/50">
           <Slider
             value={[perspective3D.rotateY]}
             onValueChange={(value) => setPerspective3D({ rotateY: value[0] })}
@@ -360,7 +410,7 @@ export function Perspective3DControls() {
         </div>
 
         {/* Rotate Z */}
-        <div className="p-3 rounded-lg bg-muted/50 border border-border/50">
+        <div ref={rotateZRef} className="p-3 rounded-lg bg-muted/50 border border-border/50">
           <Slider
             value={[perspective3D.rotateZ]}
             onValueChange={(value) => setPerspective3D({ rotateZ: value[0] })}
@@ -373,7 +423,7 @@ export function Perspective3DControls() {
         </div>
 
         {/* Translate X */}
-        <div className="p-3 rounded-lg bg-muted/50 border border-border/50">
+        <div ref={translateXRef} className="p-3 rounded-lg bg-muted/50 border border-border/50">
           <Slider
             value={[perspective3D.translateX]}
             onValueChange={(value) => setPerspective3D({ translateX: value[0] })}
@@ -386,7 +436,7 @@ export function Perspective3DControls() {
         </div>
 
         {/* Translate Y */}
-        <div className="p-3 rounded-lg bg-muted/50 border border-border/50">
+        <div ref={translateYRef} className="p-3 rounded-lg bg-muted/50 border border-border/50">
           <Slider
             value={[perspective3D.translateY]}
             onValueChange={(value) => setPerspective3D({ translateY: value[0] })}

--- a/components/controls/ShadowControls.tsx
+++ b/components/controls/ShadowControls.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { GlassInputWrapper } from '@/components/ui/glass-input-wrapper';
 import { ImageShadow } from '@/lib/store';
+import { useWheelInput } from '@/hooks/useWheelInput';
 
 interface ShadowControlsProps {
   shadow: ImageShadow;
@@ -14,6 +15,39 @@ interface ShadowControlsProps {
 }
 
 export function ShadowControls({ shadow, onShadowChange }: ShadowControlsProps) {
+  
+  const { ref: blurRef } = useWheelInput({
+      value: shadow.blur,
+      onChange: (val) => onShadowChange({ blur: val }),
+      min: 0,
+      max: 50,
+      step: 1,
+    });
+  
+  const { ref: offsetXRef } = useWheelInput({
+    value: shadow.offsetX,
+    onChange: (val) => onShadowChange({ offsetX: val }),
+    min: -20,
+    max: 20,
+    step: 1,
+  });
+
+  const { ref: offsetYRef } = useWheelInput({
+    value: shadow.offsetY,
+    onChange: (val) => onShadowChange({ offsetY: val }),
+    min: -20,
+    max: 20,
+    step: 1,
+  });
+
+  const { ref: spreadRef } = useWheelInput({
+    value: shadow.spread,
+    onChange: (val) => onShadowChange({ spread: val }),
+    min: -10,
+    max: 20,
+    step: 1,
+  });  
+  
   const presetShadows = [
     { blur: 24, offsetX: 0, offsetY: 6, spread: 3, label: 'Floating' },
     { blur: 4, offsetX: 0, offsetY: 2, spread: 0, label: 'Small' },
@@ -55,7 +89,7 @@ export function ShadowControls({ shadow, onShadowChange }: ShadowControlsProps) 
         </div>
 
         <div className="space-y-3">
-          <div className="p-3 rounded-lg bg-muted/50 border border-border/50">
+          <div ref={blurRef} className="p-3 rounded-lg bg-muted/50 border border-border/50">
             <Slider
               value={[shadow.blur]}
               onValueChange={(value) => onShadowChange({ blur: value[0] })}
@@ -67,7 +101,7 @@ export function ShadowControls({ shadow, onShadowChange }: ShadowControlsProps) 
             />
           </div>
 
-          <div className="p-3 rounded-lg bg-muted/50 border border-border/50">
+          <div ref={offsetXRef} className="p-3 rounded-lg bg-muted/50 border border-border/50">
             <Slider
               value={[shadow.offsetX]}
               onValueChange={(value) => onShadowChange({ offsetX: value[0] })}
@@ -79,7 +113,7 @@ export function ShadowControls({ shadow, onShadowChange }: ShadowControlsProps) 
             />
           </div>
 
-          <div className="p-3 rounded-lg bg-muted/50 border border-border/50">
+          <div ref={offsetYRef} className="p-3 rounded-lg bg-muted/50 border border-border/50">
             <Slider
               value={[shadow.offsetY]}
               onValueChange={(value) => onShadowChange({ offsetY: value[0] })}
@@ -91,7 +125,7 @@ export function ShadowControls({ shadow, onShadowChange }: ShadowControlsProps) 
             />
           </div>
 
-          <div className="p-3 rounded-lg bg-muted/50 border border-border/50">
+          <div ref={spreadRef} className="p-3 rounded-lg bg-muted/50 border border-border/50">
             <Slider
               value={[shadow.spread]}
               onValueChange={(value) => onShadowChange({ spread: value[0] })}

--- a/components/editor/editor-right-panel.tsx
+++ b/components/editor/editor-right-panel.tsx
@@ -18,6 +18,7 @@ import { BackgroundEffects } from '@/components/controls/BackgroundEffects';
 import { PresetGallery } from '@/components/presets/PresetGallery';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { Settings, Sparkles } from 'lucide-react';
+import { useWheelInput } from '@/hooks/useWheelInput';
 
 export function EditorRightPanel() {
   const { 
@@ -70,6 +71,23 @@ export function EditorRightPanel() {
     maxSize: MAX_IMAGE_SIZE,
     multiple: false,
   });
+  
+  const { ref: opacityRef } = useWheelInput({
+    value: backgroundConfig.opacity ?? 1,
+    onChange: setBackgroundOpacity,
+    min: 0,
+    max: 1,
+    step: 0.01,
+  });
+  
+  const { ref: borderRadiusRef } = useWheelInput({
+    value: backgroundBorderRadius,
+    onChange: setBackgroundBorderRadius,
+    min: 0,
+    max: 100,
+    step: 1,
+  });
+
 
   return (
     <div className="w-full h-full bg-[rgb(26,26,26)] flex flex-col overflow-hidden md:w-80 border-l border-border">
@@ -130,7 +148,7 @@ export function EditorRightPanel() {
                   <h4 className="text-xs font-semibold text-foreground uppercase tracking-wide">Background</h4>
               
               {/* Opacity */}
-              <div className="space-y-3">
+              <div ref={opacityRef} className="space-y-3">
                 <div className="flex justify-between items-center">
                   <Label className="text-xs font-medium text-muted-foreground">Opacity</Label>
                   <span className="text-xs text-muted-foreground font-medium">
@@ -148,7 +166,7 @@ export function EditorRightPanel() {
               </div>
 
               {/* Border Radius */}
-              <div className="space-y-3">
+              <div ref={borderRadiusRef} className="space-y-3">
                 <Label className="text-xs font-medium text-muted-foreground">Border Radius</Label>
                 <div className="flex gap-2 mb-2">
                   <Button

--- a/components/editor/style-tabs.tsx
+++ b/components/editor/style-tabs.tsx
@@ -9,6 +9,7 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { BorderControls } from '@/components/controls/BorderControls';
 import { ShadowControls } from '@/components/controls/ShadowControls';
 import { Perspective3DControls } from '@/components/controls/Perspective3DControls';
+import { useWheelInput } from '@/hooks/useWheelInput';
 
 export function StyleTabs() {
   const {
@@ -22,6 +23,31 @@ export function StyleTabs() {
     setImageShadow,
   } = useImageStore();
 
+  const { ref: radiusRef } = useWheelInput({
+    value: borderRadius,
+    onChange: setBorderRadius,
+    min: 0,
+    max: 100,
+    step: 1,
+  });
+  
+  const { ref: imageSizeRef } = useWheelInput({
+    value: imageScale,
+    onChange: setImageScale,
+    min: 10,
+    max: 200,
+    step: 1,
+  });
+  
+  const { ref: imageOpacityRef } = useWheelInput({
+    value: imageOpacity,
+    onChange: setImageOpacity,
+    min: 0,
+    max: 1,
+    step: 0.01,
+  });
+
+  
   return (
     <div className="space-y-6">
       <Tabs defaultValue="style" className="w-full">
@@ -63,7 +89,7 @@ export function StyleTabs() {
               Rounded
             </Button>
           </div>
-          <div className="p-3 rounded-lg bg-muted/50 border border-border/50">
+          <div ref={radiusRef} className="p-3 rounded-lg bg-muted/50 border border-border/50">
             <Slider
               value={[borderRadius]}
               onValueChange={(value) => setBorderRadius(value[0])}
@@ -77,7 +103,7 @@ export function StyleTabs() {
         </div>
 
         <div className="space-y-3">
-          <div className="p-3 rounded-lg bg-muted/50 border border-border/50">
+          <div ref={imageSizeRef} className="p-3 rounded-lg bg-muted/50 border border-border/50">
             <Slider
               value={[imageScale]}
               onValueChange={(value) => setImageScale(value[0])}
@@ -93,7 +119,7 @@ export function StyleTabs() {
           </p>
         </div>
 
-        <div className="p-3 rounded-lg bg-muted/50 border border-border/50">
+        <div ref={imageOpacityRef} className="p-3 rounded-lg bg-muted/50 border border-border/50">
           <Slider
             value={[imageOpacity]}
             onValueChange={(value) => setImageOpacity(value[0])}

--- a/components/mockups/MockupControls.tsx
+++ b/components/mockups/MockupControls.tsx
@@ -7,6 +7,7 @@ import { useImageStore } from '@/lib/store'
 import { Trash2, Eye, EyeOff } from 'lucide-react'
 import { getMockupDefinition } from '@/lib/constants/mockups'
 import Image from 'next/image'
+import { useWheelInput } from '@/hooks/useWheelInput'
 
 export function MockupControls() {
   const {
@@ -61,6 +62,47 @@ export function MockupControls() {
       })
     }
   }
+  
+  const { ref: sizeRef } = useWheelInput({
+    value: selectedMockup?.size ?? 600,
+    onChange: (val) => handleUpdateSize([val]),
+    min: 200,
+    max: 1200,
+    step: 10,
+  });
+  
+  const { ref: rotationRef } = useWheelInput({
+    value: selectedMockup?.rotation ?? 0,
+    onChange: (val) => handleUpdateRotation([val]),
+    min: 0,
+    max: 360,
+    step: 1,
+  });
+  
+  const { ref: opacityRef } = useWheelInput({
+    value: selectedMockup?.opacity ?? 1,
+    onChange: (val) => handleUpdateOpacity([val]),
+    min: 0,
+    max: 1,
+    step: 0.01,
+  });
+  
+  const { ref: posXRef } = useWheelInput({
+    value: selectedMockup?.position.x ?? 0,
+    onChange: (val) => handleUpdatePosition('x', [val]),
+    min: 0,
+    max: 1600,
+    step: 1,
+  });
+  
+  const { ref: posYRef } = useWheelInput({
+    value: selectedMockup?.position.y ?? 0,
+    onChange: (val) => handleUpdatePosition('y', [val]),
+    min: 0,
+    max: 1000,
+    step: 1,
+  });
+
 
   return (
     <div className="space-y-5">
@@ -150,7 +192,7 @@ export function MockupControls() {
               Edit Mockup
             </p>
 
-            <div className="p-3 rounded-xl bg-muted border border-border">
+            <div ref={sizeRef} className="p-3 rounded-xl bg-muted border border-border">
               <Slider
                 value={[selectedMockup.size]}
                 onValueChange={handleUpdateSize}
@@ -162,7 +204,7 @@ export function MockupControls() {
               />
             </div>
 
-            <div className="p-3 rounded-xl bg-muted border border-border">
+            <div ref={rotationRef} className="p-3 rounded-xl bg-muted border border-border">
               <Slider
                 value={[selectedMockup.rotation]}
                 onValueChange={handleUpdateRotation}
@@ -174,7 +216,7 @@ export function MockupControls() {
               />
             </div>
 
-            <div className="p-3 rounded-xl bg-muted border border-border">
+            <div ref={opacityRef} className="p-3 rounded-xl bg-muted border border-border">
               <Slider
                 value={[selectedMockup.opacity]}
                 onValueChange={handleUpdateOpacity}
@@ -188,7 +230,7 @@ export function MockupControls() {
 
             <div className="space-y-4">
               <p className="text-sm font-semibold text-foreground">Position</p>
-              <div className="p-3 rounded-lg bg-muted/50 border border-border/50">
+              <div ref={posXRef} className="p-3 rounded-lg bg-muted/50 border border-border/50">
                 <Slider
                   value={[selectedMockup.position.x]}
                   onValueChange={(value) => handleUpdatePosition('x', value)}
@@ -200,7 +242,7 @@ export function MockupControls() {
                 />
               </div>
 
-              <div className="p-3 rounded-lg bg-muted/50 border border-border/50">
+              <div ref={posYRef} className="p-3 rounded-lg bg-muted/50 border border-border/50">
                 <Slider
                   value={[selectedMockup.position.y]}
                   onValueChange={(value) => handleUpdatePosition('y', value)}

--- a/components/mockups/MockupControls.tsx
+++ b/components/mockups/MockupControls.tsx
@@ -28,21 +28,18 @@ export function MockupControls() {
     : null
 
   const handleUpdateSize = (value: number[]) => {
-    if (selectedMockup) {
-      updateMockup(selectedMockup.id, { size: value[0] })
-    }
+    if (!selectedMockup) return;
+    updateMockup(selectedMockup.id, { size: value[0] })
   }
 
   const handleUpdateRotation = (value: number[]) => {
-    if (selectedMockup) {
-      updateMockup(selectedMockup.id, { rotation: value[0] })
-    }
+    if (!selectedMockup) return;
+    updateMockup(selectedMockup.id, { rotation: value[0] })
   }
 
   const handleUpdateOpacity = (value: number[]) => {
-    if (selectedMockup) {
-      updateMockup(selectedMockup.id, { opacity: value[0] })
-    }
+    if (!selectedMockup) return;
+    updateMockup(selectedMockup.id, { opacity: value[0] })
   }
 
   const handleToggleVisibility = (id: string) => {
@@ -53,14 +50,13 @@ export function MockupControls() {
   }
 
   const handleUpdatePosition = (axis: 'x' | 'y', value: number[]) => {
-    if (selectedMockup) {
-      updateMockup(selectedMockup.id, {
-        position: {
-          ...selectedMockup.position,
-          [axis]: value[0],
-        },
-      })
-    }
+    if (!selectedMockup) return;
+    updateMockup(selectedMockup.id, {
+      position: {
+        ...selectedMockup.position,
+        [axis]: value[0],
+      },
+    })
   }
   
   const { ref: sizeRef } = useWheelInput({

--- a/components/overlays/overlay-controls.tsx
+++ b/components/overlays/overlay-controls.tsx
@@ -7,6 +7,7 @@ import { useImageStore } from '@/lib/store'
 import { Trash2, Eye, EyeOff } from 'lucide-react'
 import { getCldImageUrl } from '@/lib/cloudinary'
 import { OVERLAY_PUBLIC_IDS } from '@/lib/cloudinary-overlays'
+import { useWheelInput } from '@/hooks/useWheelInput'
 
 export function OverlayControls() {
   const {
@@ -69,6 +70,47 @@ export function OverlayControls() {
       })
     }
   }
+  
+  const { ref: sizeRef } = useWheelInput({
+    value: selectedOverlay?.size ?? 100,
+    onChange: (val) => handleUpdateSize([val]),
+    min: 20,
+    max: 400,
+    step: 1,
+  });
+  
+  const { ref: rotationRef } = useWheelInput({
+    value: selectedOverlay?.rotation ?? 0,
+    onChange: (val) => handleUpdateRotation([val]),
+    min: 0,
+    max: 360,
+    step: 1,
+  });
+  
+  const { ref: opacityRef } = useWheelInput({
+    value: selectedOverlay?.opacity ?? 1,
+    onChange: (val) => handleUpdateOpacity([val]),
+    min: 0,
+    max: 1,
+    step: 0.01,
+  });
+  
+  const { ref: posXRef } = useWheelInput({
+    value: selectedOverlay?.position.x ?? 0,
+    onChange: (val) => handleUpdatePosition('x', [val]),
+    min: 0,
+    max: 800,
+    step: 1,
+  });
+  
+  const { ref: posYRef } = useWheelInput({
+    value: selectedOverlay?.position.y ?? 0,
+    onChange: (val) => handleUpdatePosition('y', [val]),
+    min: 0,
+    max: 600,
+    step: 1,
+  });
+
 
   return (
     <div className="space-y-5">
@@ -171,7 +213,7 @@ export function OverlayControls() {
             </p>
 
             {/* Size */}
-            <div className="p-3 rounded-xl bg-muted border border-border">
+            <div ref={sizeRef} className="p-3 rounded-xl bg-muted border border-border">
               <Slider
                 value={[selectedOverlay.size]}
                 onValueChange={handleUpdateSize}
@@ -184,7 +226,7 @@ export function OverlayControls() {
             </div>
 
             {/* Rotation */}
-            <div className="p-3 rounded-xl bg-muted border border-border">
+            <div ref={rotationRef} className="p-3 rounded-xl bg-muted border border-border">
               <Slider
                 value={[selectedOverlay.rotation]}
                 onValueChange={handleUpdateRotation}
@@ -197,7 +239,7 @@ export function OverlayControls() {
             </div>
 
             {/* Opacity */}
-            <div className="p-3 rounded-xl bg-muted border border-border">
+            <div ref={opacityRef} className="p-3 rounded-xl bg-muted border border-border">
               <Slider
                 value={[selectedOverlay.opacity]}
                 onValueChange={handleUpdateOpacity}
@@ -233,7 +275,7 @@ export function OverlayControls() {
             <div className="space-y-4">
               <p className="text-sm font-semibold text-foreground">Position</p>
               {/* X position */}
-              <div className="p-3 rounded-lg bg-muted/50 border border-border/50">
+              <div ref={posXRef} className="p-3 rounded-lg bg-muted/50 border border-border/50">
                 <Slider
                   value={[selectedOverlay.position.x]}
                   onValueChange={(value) => handleUpdatePosition('x', value)}
@@ -246,7 +288,7 @@ export function OverlayControls() {
               </div>
 
               {/* Y position */}
-              <div className="p-3 rounded-lg bg-muted/50 border border-border/50">
+              <div ref={posYRef} className="p-3 rounded-lg bg-muted/50 border border-border/50">
                 <Slider
                   value={[selectedOverlay.position.y]}
                   onValueChange={(value) => handleUpdatePosition('y', value)}

--- a/components/overlays/overlay-controls.tsx
+++ b/components/overlays/overlay-controls.tsx
@@ -24,33 +24,32 @@ export function OverlayControls() {
   )
 
   const handleUpdateSize = (value: number[]) => {
+    if (!selectedOverlay) return;
     if (selectedOverlay) {
       updateImageOverlay(selectedOverlay.id, { size: value[0] })
     }
   }
 
   const handleUpdateRotation = (value: number[]) => {
+    if (!selectedOverlay) return;
     if (selectedOverlay) {
       updateImageOverlay(selectedOverlay.id, { rotation: value[0] })
     }
   }
 
   const handleUpdateOpacity = (value: number[]) => {
-    if (selectedOverlay) {
-      updateImageOverlay(selectedOverlay.id, { opacity: value[0] })
-    }
+    if (!selectedOverlay) return;
+    updateImageOverlay(selectedOverlay.id, { opacity: value[0] })
   }
 
   const handleToggleFlipX = () => {
-    if (selectedOverlay) {
-      updateImageOverlay(selectedOverlay.id, { flipX: !selectedOverlay.flipX })
-    }
+    if (!selectedOverlay) return;
+    updateImageOverlay(selectedOverlay.id, { flipX: !selectedOverlay.flipX })
   }
 
   const handleToggleFlipY = () => {
-    if (selectedOverlay) {
-      updateImageOverlay(selectedOverlay.id, { flipY: !selectedOverlay.flipY })
-    }
+    if (!selectedOverlay) return;
+    updateImageOverlay(selectedOverlay.id, { flipY: !selectedOverlay.flipY })
   }
 
   const handleToggleVisibility = (id: string) => {
@@ -61,14 +60,13 @@ export function OverlayControls() {
   }
 
   const handleUpdatePosition = (axis: 'x' | 'y', value: number[]) => {
-    if (selectedOverlay) {
-      updateImageOverlay(selectedOverlay.id, {
-        position: {
-          ...selectedOverlay.position,
-          [axis]: value[0],
-        },
-      })
-    }
+    if (!selectedOverlay) return;
+    updateImageOverlay(selectedOverlay.id, {
+      position: {
+        ...selectedOverlay.position,
+        [axis]: value[0],
+      },
+    })
   }
   
   const { ref: sizeRef } = useWheelInput({

--- a/components/text-overlay/text-overlay-controls.tsx
+++ b/components/text-overlay/text-overlay-controls.tsx
@@ -15,6 +15,7 @@ import { GlassInputWrapper } from '@/components/ui/glass-input-wrapper';
 import { useImageStore } from '@/lib/store';
 import {  Trash2, Eye, EyeOff } from 'lucide-react';
 import { fontFamilies, getAvailableFontWeights } from '@/lib/constants/fonts';
+import { useWheelInput } from '@/hooks/useWheelInput';
 
 export const TextOverlayControls = () => {
   const {
@@ -152,6 +153,62 @@ export const TextOverlayControls = () => {
       updateTextOverlay(id, { isVisible: !overlay.isVisible });
     }
   };
+  
+  const { ref: fontSizeRef } = useWheelInput({
+    value: selectedOverlay?.fontSize ?? 24,
+    onChange: (val) => handleUpdateFontSize([val]),
+    min: 12,
+    max: 150,
+    step: 1,
+  });
+  
+  const { ref: opacityRef } = useWheelInput({
+    value: selectedOverlay?.opacity ?? 1,
+    onChange: (val) => handleUpdateOpacity([val]),
+    min: 0,
+    max: 1,
+    step: 0.01,
+  });
+  
+  const { ref: shadowBlurRef } = useWheelInput({
+    value: selectedOverlay?.textShadow.blur ?? 0,
+    onChange: (val) => handleUpdateTextShadow({ blur: val }),
+    min: 0,
+    max: 20,
+    step: 1,
+  });
+  
+  const { ref: shadowOffsetXRef } = useWheelInput({
+    value: selectedOverlay?.textShadow.offsetX ?? 0,
+    onChange: (val) => handleUpdateTextShadow({ offsetX: val }),
+    min: -20,
+    max: 20,
+    step: 1,
+  });
+  
+  const { ref: shadowOffsetYRef } = useWheelInput({
+    value: selectedOverlay?.textShadow.offsetY ?? 0,
+    onChange: (val) => handleUpdateTextShadow({ offsetY: val }),
+    min: -20,
+    max: 20,
+    step: 1,
+  });
+  
+  const { ref: positionXRef } = useWheelInput({
+    value: selectedOverlay?.position.x ?? 50,
+    onChange: (val) => handleUpdatePosition('x', [val]),
+    min: 0,
+    max: 100,
+    step: 1,
+  });
+  
+  const { ref: positionYRef } = useWheelInput({
+    value: selectedOverlay?.position.y ?? 50,
+    onChange: (val) => handleUpdatePosition('y', [val]),
+    min: 0,
+    max: 100,
+    step: 1,
+  });
 
   return (
     <div className="space-y-5">
@@ -336,7 +393,7 @@ export const TextOverlayControls = () => {
 
             <div className="flex items-center gap-3 p-3 rounded-xl bg-muted border border-border">
               <span className="text-sm font-medium text-foreground whitespace-nowrap">Font Size</span>
-              <div className="flex-1 flex items-center gap-3">
+              <div ref={fontSizeRef} className="flex-1 flex items-center gap-3">
                 <Slider
                   value={[selectedOverlay.fontSize]}
                   onValueChange={handleUpdateFontSize}
@@ -350,7 +407,7 @@ export const TextOverlayControls = () => {
 
             <div className="flex items-center gap-3 p-3 rounded-xl bg-muted border border-border">
               <span className="text-sm font-medium text-foreground whitespace-nowrap">Opacity</span>
-              <div className="flex-1 flex items-center gap-3">
+              <div ref={opacityRef} className="flex-1 flex items-center gap-3">
                 <Slider
                   value={[selectedOverlay.opacity]}
                   onValueChange={handleUpdateOpacity}
@@ -409,7 +466,7 @@ export const TextOverlayControls = () => {
                   {/* Shadow Blur */}
                   <div className="flex items-center gap-3 p-3 rounded-lg bg-muted/50 border border-border/50">
                     <span className="text-sm font-medium text-foreground whitespace-nowrap">Blur</span>
-                    <div className="flex-1 flex items-center gap-3">
+                    <div ref={shadowBlurRef} className="flex-1 flex items-center gap-3">
                       <Slider
                         value={[selectedOverlay.textShadow.blur]}
                         onValueChange={(value) =>
@@ -426,7 +483,7 @@ export const TextOverlayControls = () => {
                   {/* Shadow Offset X */}
                   <div className="flex items-center gap-3 p-3 rounded-lg bg-muted/50 border border-border/50">
                     <span className="text-sm font-medium text-foreground whitespace-nowrap">Offset X</span>
-                    <div className="flex-1 flex items-center gap-3">
+                    <div ref={shadowOffsetXRef} className="flex-1 flex items-center gap-3">
                       <Slider
                         value={[selectedOverlay.textShadow.offsetX]}
                         onValueChange={(value) =>
@@ -443,7 +500,7 @@ export const TextOverlayControls = () => {
                   {/* Shadow Offset Y */}
                   <div className="flex items-center gap-3 p-3 rounded-lg bg-muted/50 border border-border/50">
                     <span className="text-sm font-medium text-foreground whitespace-nowrap">Offset Y</span>
-                    <div className="flex-1 flex items-center gap-3">
+                    <div ref={shadowOffsetYRef} className="flex-1 flex items-center gap-3">
                       <Slider
                         value={[selectedOverlay.textShadow.offsetY]}
                         onValueChange={(value) =>
@@ -465,7 +522,7 @@ export const TextOverlayControls = () => {
                 Position
               </p>
               {/* X position */}
-              <div className="p-3 rounded-lg bg-muted/50 border border-border/50">
+              <div ref={positionXRef} className="p-3 rounded-lg bg-muted/50 border border-border/50">
                 <Slider
                   value={[selectedOverlay.position.x]}
                   onValueChange={(value) => handleUpdatePosition('x', value)}
@@ -478,7 +535,7 @@ export const TextOverlayControls = () => {
               </div>
 
               {/* Y position */}
-              <div className="p-3 rounded-lg bg-muted/50 border border-border/50">
+              <div ref={positionYRef} className="p-3 rounded-lg bg-muted/50 border border-border/50">
                 <Slider
                   value={[selectedOverlay.position.y]}
                   onValueChange={(value) => handleUpdatePosition('y', value)}

--- a/hooks/useWheelInput.ts
+++ b/hooks/useWheelInput.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import { useCallback, useRef, useEffect } from "react";
+
+interface UseWheelInputOptions {
+  value: number;
+  onChange: (value: number) => void;
+  min?: number;
+  max?: number;
+  step?: number;
+}
+
+export function useWheelInput({
+  value,
+  onChange,
+  min = -Infinity,
+  max = Infinity,
+  step = 1,
+}: UseWheelInputOptions) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  const handleWheel = useCallback(
+    (e: WheelEvent) => {
+      e.preventDefault();
+      const delta = e.deltaY > 0 ? -step : step;
+      const multiplier = e.shiftKey ? 10 : e.ctrlKey || e.metaKey ? 0.1 : 1;
+      const rawValue = value + delta * multiplier;
+      const precision = step < 1 ? Math.ceil(-Math.log10(step)) : 0;
+      const newValue = Math.min(
+        max,
+        Math.max(min, parseFloat(rawValue.toFixed(precision))),
+      );
+      onChange(newValue);
+    },
+    [value, onChange, min, max, step],
+  );
+
+  useEffect(() => {
+    const element = ref.current;
+    if (element) {
+      element.addEventListener("wheel", handleWheel, { passive: false });
+      return () => element.removeEventListener("wheel", handleWheel);
+    }
+  }, [handleWheel]);
+
+  return { ref };
+}

--- a/hooks/useWheelInput.ts
+++ b/hooks/useWheelInput.ts
@@ -2,6 +2,22 @@
 
 import { useCallback, useRef, useEffect } from "react";
 
+/**
+ * Hook that enables mouse wheel input for numeric value adjustments.
+ *
+ * @param value - Current numeric value
+ * @param onChange - Callback function when value changes
+ * @param min - Minimum allowed value (default: -Infinity)
+ * @param max - Maximum allowed value (default: Infinity)
+ * @param step - Base increment/decrement step (default: 1)
+ *
+ * @returns Object with a ref to attach to the container element
+ *
+ * @remarks
+ * Supports modifier keys:
+ * - Shift: 10x step multiplier
+ * - Ctrl/Cmd: 0.1x step multiplier
+ */
 interface UseWheelInputOptions {
   value: number;
   onChange: (value: number) => void;
@@ -18,21 +34,26 @@ export function useWheelInput({
   step = 1,
 }: UseWheelInputOptions) {
   const ref = useRef<HTMLDivElement>(null);
+  const valueRef = useRef(value);
+
+  useEffect(() => {
+    valueRef.current = value;
+  }, [value]);
 
   const handleWheel = useCallback(
     (e: WheelEvent) => {
       e.preventDefault();
       const delta = e.deltaY > 0 ? -step : step;
       const multiplier = e.shiftKey ? 10 : e.ctrlKey || e.metaKey ? 0.1 : 1;
-      const rawValue = value + delta * multiplier;
-      const precision = step < 1 ? Math.ceil(-Math.log10(step)) : 0;
+      const rawValue = valueRef.current + delta * multiplier;
+      const precision = step < 1 ? Math.abs(step.toString().split('.')[1]?.length ?? 0) : 0;
       const newValue = Math.min(
         max,
         Math.max(min, parseFloat(rawValue.toFixed(precision))),
       );
       onChange(newValue);
     },
-    [value, onChange, min, max, step],
+    [onChange, min, max, step],
   );
 
   useEffect(() => {


### PR DESCRIPTION
added mouse wheel input to editor slider controls

- added a useWheelInput hook that enables mouse-wheel scrolling to adjust slider values on sliders throughout the editor