### PR TITLE
fix(canvas): fix background images stretch on canvas issue

### DIFF
--- a/components/canvas/layers/BackgroundLayer.tsx
+++ b/components/canvas/layers/BackgroundLayer.tsx
@@ -68,23 +68,36 @@ export function BackgroundLayer({
           height={canvasH}
           // Calculate cropping to simulate object-fit: cover
           crop={(() => {
-            const imageRatio = bgImage.width / bgImage.height;
+            const imageWidth = bgImage.width;
+            const imageHeight = bgImage.height;
+
+            // Guard against invalid or zero dimensions to avoid division by zero
+            if (imageHeight <= 0 || canvasW <= 0 || canvasH <= 0) {
+              return {
+                x: 0,
+                y: 0,
+                width: imageWidth,
+                height: imageHeight,
+              };
+            }
+
+            const imageRatio = imageWidth / imageHeight;
             const canvasRatio = canvasW / canvasH;
 
             let cropWidth, cropHeight, cropX, cropY;
 
             if (imageRatio > canvasRatio) {
               // Image is wider than canvas - crop sides
-              cropHeight = bgImage.height;
-              cropWidth = bgImage.height * canvasRatio;
-              cropX = (bgImage.width - cropWidth) / 2;
+              cropHeight = imageHeight;
+              cropWidth = imageHeight * canvasRatio;
+              cropX = (imageWidth - cropWidth) / 2;
               cropY = 0;
             } else {
               // Image is taller than canvas - crop top/bottom
-              cropWidth = bgImage.width;
-              cropHeight = bgImage.width / canvasRatio;
+              cropWidth = imageWidth;
+              cropHeight = imageWidth / canvasRatio;
               cropX = 0;
-              cropY = (bgImage.height - cropHeight) / 2;
+              cropY = (imageHeight - cropHeight) / 2;
             }
 
             return {


### PR DESCRIPTION
## Description
Fixed an issue where background images were stretching to fill the canvas dimensions regardless of aspect ratio. Implemented dynamic cropping (similar to CSS `object-fit: cover`) directly in the Konva [BackgroundLayer](cci:1://file:///c:/Users/karan%20singh/Documents/MY%20PORTOFOLIO%20DESIGNS/Code%20Playground/heykaran/CodeArc/open-sourcing/stage/components/canvas/layers/BackgroundLayer.tsx:20:0-163:1) to ensure images remain centered and maintain their aspect ratio while filling the canvas.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tested manually
- [x] TypeScript compiles without errors
- [x] No console errors

## Screenshots
### 16:9 Ratio
<img width="1919" height="916" alt="Screenshot 2025-12-18 140955" src="https://github.com/user-attachments/assets/6b2debab-d64a-4ec3-9be9-c12a4a02db0a" />
### 1:1 Square Before
<img width="1919" height="974" alt="Screenshot 2025-12-18 141007" src="https://github.com/user-attachments/assets/fe2a754b-8541-4927-b0a8-f17c5cd15060" />
### 1:1 Square After
<img width="1919" height="975" alt="Screenshot 2025-12-18 141016" src="https://github.com/user-attachments/assets/7148f0c5-492d-4bb8-a357-9db7bb81692f" />


## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex code
- [ ] Documentation updated
- [x] No new warnings generated