### PR TITLE
Fix: added pointer event listener for removing image selection when click outside

### DIFF
--- a/components/canvas/ClientCanvas.tsx
+++ b/components/canvas/ClientCanvas.tsx
@@ -84,7 +84,7 @@ function CanvasRenderer({ image }: { image: HTMLImageElement }) {
   const loadedOverlayImages = useOverlayImages(imageOverlays);
 
   useEffect(() => {                                           // deleting overlays when backspace or delete is pressed
-    const handleKeyDown = (e: KeyboardEvent) => {            
+    const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key == 'Delete' || e.key == 'Backspace'){ 
         if (selectedOverlayId){
           e.preventDefault()
@@ -96,6 +96,30 @@ function CanvasRenderer({ image }: { image: HTMLImageElement }) {
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
   },[selectedOverlayId, removeImageOverlay])
+
+
+  // to clear selection while clicking outside of canvas
+  useEffect(() => {
+    const handlePointerDown = (e: PointerEvent) => {
+      const target = e.target as Node | null;
+      if (!target) return;
+
+      const container = containerRef.current;
+      if (!container) return;
+
+      
+      if (!container.contains(target)) {
+        setSelectedOverlayId(null);
+        setIsMainImageSelected(false);
+        setSelectedTextId(null);
+      }
+    };
+
+    document.addEventListener('pointerdown', handlePointerDown, true);
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown, true);
+    };
+  }, []);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -118,7 +142,7 @@ function CanvasRenderer({ image }: { image: HTMLImageElement }) {
           undo();
         }
       }
-    }
+    };
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);


### PR DESCRIPTION
### Bug Description
> When an image/overlay is selected on the canvas and the user clicks outside the canvas area, the selection remains active instead of being cleared.
> selection still visible in generated image

### Steps to Reproduce
> Open stage
> add image
> Click an image overlay) to select it.
> Click anywhere outside the canvas container (e.g. area outside the canvas).
> Observe that the selection remains.
> download image it still visible in image

### Expected Behavior
> selection should be cleared when clicking outside the canvas area

### Actual Behavior
> selection remains active after clicking outside the canvas area.


![result](https://github.com/user-attachments/assets/b97ba664-ca23-4a5f-a30b-ecb66e3e3982)
