### PR TITLE
Fix/howitworks align

### DIFF
--- a/components/landing/HowItWorks.tsx
+++ b/components/landing/HowItWorks.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useId } from "react";
 import { motion } from "motion/react";
 import { Instrument_Serif } from "next/font/google";
 
@@ -23,11 +24,12 @@ export function HowItWorks({
   steps,
   title = "How It Works",
 }: HowItWorksProps) {
+  const titleId = useId();
   return (
-    <section aria-labelledby="how-it-works-title" className="py-20 sm:py-28 md:py-32 px-6 bg-background">
+    <section aria-labelledby={titleId} className="py-20 sm:py-28 md:py-32 px-6 bg-background">
       <div className="container mx-auto max-w-4xl">
         <motion.h2
-          id="how-it-works-title"
+          id={titleId}
           initial={{ opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}


### PR DESCRIPTION
## Description

Fixes the alignment of the **HowItWorks** section by centering the grid while preserving the original left-aligned content inside each step card.

Additionally improves accessibility by linking the section to its heading using React’s `useId()` to avoid duplicate ID issues when the component is reused.

## Type of Change

* [x] Bug fix
* [x] Accessibility improvement

## What Changed

* Centered the steps grid using intrinsic column sizing
* Preserved existing responsive text alignment
* Replaced hardcoded heading ID with `useId()` for safe reuse
* Added `aria-labelledby` for better screen reader support

## Testing

* [x] Tested manually in browser
* [x] Layout verified across breakpoints
* [x] TypeScript compiles successfully
* [x] No console errors

## Screenshots / Video

<!-- Add your video here -->
Before - 
<img width="1800" height="1130" alt="image" src="https://github.com/user-attachments/assets/705f5d81-c23a-4e9b-af1a-a6aa594d9eac" />


After -
<img width="1800" height="1132" alt="image" src="https://github.com/user-attachments/assets/c8ca285e-0784-4896-baa9-8c046849193f" />



## Checklist

* [x] Code follows project style guidelines
* [x] Self-review completed
* [x] No new warnings introduced
