### PR TITLE
fix: preserve styles on drag/drop and paste image replace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@
 .DS_Store
 *.pem
 
+# Claude Code local settings
+.claude/
+
 # debug
 npm-debug.log*
 yarn-debug.log*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,112 @@
+# CLAUDE.md — Screenshot Studio
+
+> For full architecture details, see [ARCHITECTURE.md](./ARCHITECTURE.md).
+
+## Project Overview
+
+Screenshot Studio is a free, browser-based visual editor for creating screenshots, animated visuals, and video exports. No signup, no watermarks. Live at [screenshot-studio.com](https://screenshot-studio.com).
+
+## Dev Setup
+
+```bash
+# Requires .env with a DATABASE_URL (even a dummy value — only needed for prisma generate)
+echo 'DATABASE_URL="postgresql://localhost:5432/screenshot_studio"' > .env
+
+npm install
+npm run dev        # → http://localhost:3000
+```
+
+- `npm run dev` runs `prisma generate` before `next dev --webpack`
+- Core features work without a real DB or R2 — only website screenshot caching needs them
+- The editor lives at `/home`
+
+## Tech Stack
+
+| Area | Tech |
+|---|---|
+| Framework | Next.js 16 (App Router), React 19, TypeScript 5.9 |
+| Styling | Tailwind CSS 4, Radix UI, shadcn/ui (`components/ui/`) |
+| State | Zustand 5 + Zundo (undo/redo on `useImageStore`) |
+| Canvas | HTML/CSS background + Konva user image (hybrid) |
+| Animation | Custom keyframe engine (`lib/animation/`) |
+| Video Export | WebCodecs + FFmpeg WASM + mp4-muxer |
+| DB / Storage | Prisma + PostgreSQL, Cloudflare R2, IndexedDB |
+| Icons | Hugeicons (`hugeicons-react`) |
+
+## Key Architecture
+
+### Dual Store Pattern
+- **`useImageStore`** (`lib/store/index.ts`) — source of truth: image URL, all styles, overlays, timeline, slides. Wrapped with Zundo for undo/redo.
+- **`useEditorStore`** (`lib/store/index.ts`) — canvas render state (screenshot src, dimensions, patterns). Kept in sync via `EditorStoreSync` component.
+
+### Canvas Layers (composited on export)
+1. Background — HTML/CSS, captured with `modern-screenshot`
+2. User image — Konva stage
+3. Overlays (text + image) — composited on top
+
+### Image Upload Flow
+```
+User drops/pastes file
+  → addImages(files)        [imageStore: creates slide + sets uploadedImageUrl]
+  → setScreenshot({ src })  [editorStore: triggers canvas render]
+  → ClientCanvas re-renders
+```
+
+### Replace Image Flow (new — preserves styles)
+```
+User drops/pastes while image is loaded
+  → replaceImage(file)      [imageStore: swaps URL only, all styles untouched]
+  → setScreenshot({ src })  [editorStore: triggers canvas render]
+```
+
+## Important Files
+
+| File | Purpose |
+|---|---|
+| `lib/store/index.ts` | All Zustand state — `useImageStore` + `useEditorStore` |
+| `components/canvas/EditorCanvas.tsx` | Canvas area — routes between upload state and canvas, holds global drag/drop/paste handlers |
+| `components/canvas/ClientCanvas.tsx` | Konva canvas renderer (client-only, dynamic import) |
+| `components/controls/CleanUploadState.tsx` | Upload dropzone UI (shown before first image) |
+| `lib/animation/interpolation.ts` | Keyframe interpolation engine |
+| `lib/animation/presets.ts` | 20+ animation presets in 5 categories |
+| `lib/export/export-slideshow-video.ts` | Video export orchestrator |
+| `lib/constants.ts` | `MAX_IMAGE_SIZE`, `ALLOWED_IMAGE_TYPES` |
+| `lib/constants/` | Backgrounds, gradients, solid colors, fonts, aspect ratios, presets |
+| `types/animation.ts` | `Keyframe`, `AnimationTrack`, `AnimationClip`, `TimelineState` types |
+
+## State: What setImage vs replaceImage Does
+
+| Action | Use Case | Resets Styles? |
+|---|---|---|
+| `setImage(file)` | First image upload (via `addImages`) | YES — full reset to defaults |
+| `replaceImage(file)` | Swap image after one is loaded | NO — only swaps URL + name |
+| `clearImage()` | Remove button | YES — full reset |
+
+## Global Drag/Drop/Paste (after image is loaded)
+
+Handled in `EditorCanvas.tsx` via `useEffect` on `hasImage`:
+- `window dragover` → `preventDefault()` + show drop overlay
+- `window drop` → validate type/size → `replaceImage` + `setScreenshot`
+- `document paste` → skips INPUT/TEXTAREA targets → same swap
+- All listeners cleaned up on unmount
+
+## Conventions
+
+- Components use named exports (`export function Foo`)
+- Tailwind utility classes; `cn()` from `lib/utils` for conditional classes
+- Store actions are co-located in `lib/store/index.ts` (single file)
+- Icon imports from `hugeicons-react`
+- `noClick: true` on dropzone in `CleanUploadState` — click is handled by the card `onClick={open}`
+- Background assets served from Cloudflare R2; `getR2ImageUrl()` in `lib/r2.ts` handles URL construction
+
+## Recent Changes
+
+| Date | Change |
+|---|---|
+| 2026-03-03 | Added `replaceImage` store action — swaps image URL while preserving all styles |
+| 2026-03-03 | Global drag/drop/paste handlers in `EditorCanvas` — fixes browser opening images in new tab after first upload |
+| 2026-03-03 | Drop overlay with "Drop to replace image / Your styles will be preserved" feedback |
+
+---
+
+_Last updated: 2026-03-03 — initial CLAUDE.md created; drag/drop replace bug fixed_

--- a/components/canvas/EditorCanvas.tsx
+++ b/components/canvas/EditorCanvas.tsx
@@ -11,7 +11,9 @@ import {
   Video01Icon,
   ArrowTurnBackwardIcon,
   ArrowTurnForwardIcon,
+  Image01Icon,
 } from "hugeicons-react";
+import { ALLOWED_IMAGE_TYPES, MAX_IMAGE_SIZE } from "@/lib/constants";
 import { useState, useEffect, useCallback } from "react";
 import React from "react";
 import { cn } from "@/lib/utils";
@@ -27,7 +29,7 @@ const ClientCanvas = dynamic(() => import("@/components/canvas/ClientCanvas"), {
 });
 
 export function EditorCanvas() {
-  const { screenshot } = useEditorStore();
+  const { screenshot, setScreenshot } = useEditorStore();
   const {
     slides,
     setActiveSlide,
@@ -38,6 +40,7 @@ export function EditorCanvas() {
     stopPreview,
     uploadedImageUrl,
     clearImage,
+    replaceImage,
     showTimeline,
     timeline,
     animationClips,
@@ -46,6 +49,63 @@ export function EditorCanvas() {
   // Check both stores - imageStore is the source of truth (tracked by undo/redo)
   const hasImage = !!uploadedImageUrl && !!screenshot.src;
   const [exportOpen, setExportOpen] = useState(false);
+  const [isDragOver, setIsDragOver] = useState(false);
+
+  // When an image is loaded, intercept drag/drop and paste globally so the
+  // browser never opens files in a new tab and styles are preserved on swap.
+  useEffect(() => {
+    if (!hasImage) return;
+
+    const handleDragOver = (e: DragEvent) => {
+      e.preventDefault();
+      if (e.dataTransfer?.types.includes("Files")) setIsDragOver(true);
+    };
+
+    const handleDragLeave = (e: DragEvent) => {
+      if (!e.relatedTarget) setIsDragOver(false);
+    };
+
+    const handleDrop = (e: DragEvent) => {
+      e.preventDefault();
+      setIsDragOver(false);
+      const file = Array.from(e.dataTransfer?.files ?? []).find(
+        (f) => ALLOWED_IMAGE_TYPES.includes(f.type) && f.size <= MAX_IMAGE_SIZE
+      );
+      if (!file) return;
+      replaceImage(file);
+      setScreenshot({ src: URL.createObjectURL(file) });
+    };
+
+    const handlePaste = (e: ClipboardEvent) => {
+      const target = e.target as HTMLElement;
+      if (target.tagName === "INPUT" || target.tagName === "TEXTAREA") return;
+      const items = e.clipboardData?.items;
+      if (!items) return;
+      for (const item of Array.from(items)) {
+        if (item.type.startsWith("image/")) {
+          e.preventDefault();
+          const file = item.getAsFile();
+          if (file) {
+            replaceImage(file);
+            setScreenshot({ src: URL.createObjectURL(file) });
+          }
+          break;
+        }
+      }
+    };
+
+    window.addEventListener("dragover", handleDragOver);
+    window.addEventListener("dragleave", handleDragLeave);
+    window.addEventListener("drop", handleDrop);
+    document.addEventListener("paste", handlePaste);
+
+    return () => {
+      window.removeEventListener("dragover", handleDragOver);
+      window.removeEventListener("dragleave", handleDragLeave);
+      window.removeEventListener("drop", handleDrop);
+      document.removeEventListener("paste", handlePaste);
+    };
+  }, [hasImage, replaceImage, setScreenshot]);
 
   // Track temporal state reactively for undo/redo
   const [canUndo, setCanUndo] = React.useState(false);
@@ -126,6 +186,16 @@ export function EditorCanvas() {
   return (
     <>
       <div className="flex flex-col h-full w-full relative">
+        {/* Drop-to-replace overlay — shown when dragging a file over the canvas */}
+        {isDragOver && (
+          <div className="absolute inset-0 z-50 pointer-events-none flex items-center justify-center bg-black/50 backdrop-blur-sm">
+            <div className="flex flex-col items-center gap-3 text-foreground border-2 border-dashed border-foreground/40 rounded-2xl px-12 py-10">
+              <Image01Icon size={48} className="text-foreground/70" />
+              <p className="text-lg font-semibold">Drop to replace image</p>
+              <p className="text-sm text-text-secondary">Your styles will be preserved</p>
+            </div>
+          </div>
+        )}
         {/* Secondary toolbar for slides and image management */}
         {(slides.length > 0 || uploadedImageUrl) && (
           <div className="flex items-center justify-between gap-2 p-2 border-b border-border/30 bg-[#1e1e1e] shrink-0">

--- a/lib/r2.ts
+++ b/lib/r2.ts
@@ -22,17 +22,13 @@
  * @returns The proxied URL path
  */
 export function getR2PublicUrl(path: string): string {
-  const publicUrl = process.env.NEXT_PUBLIC_R2_PUBLIC_URL;
-
-  if (!publicUrl) {
-    console.warn('R2_PUBLIC_URL not configured. Using path as-is.');
-    return path;
-  }
-
   // Remove leading slash from path if present
   const cleanPath = path.startsWith('/') ? path.slice(1) : path;
 
-  // Use same-origin proxy to avoid CORS issues with canvas capture
+  // Always use the same-origin proxy path so next/image receives a valid URL
+  // (must start with "/"). When NEXT_PUBLIC_R2_PUBLIC_URL is not configured the
+  // Next.js rewrite in next.config.ts won't proxy the request, so the image will
+  // 404 — but that is handled gracefully by onError rather than crashing the app.
   return `/r2-assets/${cleanPath}`;
 }
 

--- a/lib/store/index.ts
+++ b/lib/store/index.ts
@@ -524,6 +524,7 @@ export interface ImageState {
   };
   setUploadedImageUrl: (url: string | null, name: string | null) => void;
   setImage: (file: File) => void;
+  replaceImage: (file: File) => void;
   clearImage: () => void;
   setGradient: (gradient: GradientKey) => void;
   setBorderRadius: (radius: number) => void;
@@ -770,6 +771,20 @@ export const useImageStore = create<ImageState>()(
         timeline: { ...DEFAULT_TIMELINE_STATE },
         animationClips: [],
         showTimeline: false,
+      });
+    },
+
+    replaceImage: (file: File) => {
+      const { uploadedImageUrl: oldUrl, slides, activeSlideId } = get();
+      if (oldUrl) URL.revokeObjectURL(oldUrl);
+      const imageUrl = URL.createObjectURL(file);
+      const updatedSlides = slides.map((slide) =>
+        slide.id === activeSlideId ? { ...slide, src: imageUrl, name: file.name } : slide
+      );
+      set({
+        uploadedImageUrl: imageUrl,
+        imageName: file.name,
+        ...(slides.length > 0 ? { slides: updatedSlides } : {}),
       });
     },
 


### PR DESCRIPTION
## Description

Fixes a UX bug where dragging or pasting a new image onto the canvas after the first upload would open it in the browser's new tab instead of swapping it in the editor.

## Changes

- **`lib/store/index.ts`** — new `replaceImage` action that swaps the image URL/name only, leaving all applied styles (shadow, border, background, 3D, overlays, etc.) completely untouched
- **`components/canvas/EditorCanvas.tsx`** — global `dragover`/`dragleave`/`drop` and `document paste` listeners active only while an image is loaded; listeners are cleaned up on unmount
- **`components/canvas/EditorCanvas.tsx`** — drop overlay UI showing "Drop to replace image / Your styles will be preserved" while a file is being dragged over the canvas
- **`lib/r2.ts`** — simplified `getR2PublicUrl` to always return the same-origin `/r2-assets/` proxy path; missing `NEXT_PUBLIC_R2_PUBLIC_URL` env var now fails gracefully via `onError` rather than crashing
- **`.gitignore`** — added `.claude/` to keep local Claude Code settings out of version control
- **`CLAUDE.md`** — added project context file for contributors using Claude Code

## Type of Change

- [x] Bug fix (drag/drop/paste opening images in new tab)
- [x] New feature (`replaceImage` store action)

## Testing

- [x] Drag a new image onto the canvas after first upload — browser no longer opens it in a new tab; styles are preserved
- [x] Paste an image via Ctrl+V — styles preserved, no new tab
- [x] Drop overlay appears while dragging and dismisses correctly on drop or drag-leave
- [x] TypeScript compiles without errors
- [x] No new lint errors introduced (all pre-existing)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No new warnings generated