### PR TITLE
perf: scope store subscriptions to prevent panel re-renders on resize

### DIFF
--- a/components/editor/LeftEditPanel.tsx
+++ b/components/editor/LeftEditPanel.tsx
@@ -38,7 +38,8 @@ const leftTabs: { id: LeftTabType; icon: React.ReactNode; label: string }[] = [
 ];
 
 function ModeDropdown() {
-  const { editorMode, setEditorMode } = useImageStore();
+  const editorMode = useImageStore((s) => s.editorMode);
+  const setEditorMode = useImageStore((s) => s.setEditorMode);
   const [open, setOpen] = React.useState(false);
   const ref = React.useRef<HTMLDivElement>(null);
 
@@ -96,7 +97,9 @@ function ModeDropdown() {
 }
 
 export function LeftEditPanel() {
-  const { showTemplates: templatesOpen, setShowTemplates: setTemplatesOpen, editorMode } = useImageStore();
+  const templatesOpen = useImageStore((s) => s.showTemplates);
+  const setTemplatesOpen = useImageStore((s) => s.setShowTemplates);
+  const editorMode = useImageStore((s) => s.editorMode);
   const [activeTab, setActiveTab] = React.useState<LeftTabType>('edit');
 
   const [contentKey, setContentKey] = React.useState<LeftTabType>(activeTab);

--- a/components/editor/RightSettingsPanel.tsx
+++ b/components/editor/RightSettingsPanel.tsx
@@ -345,11 +345,27 @@ function PerspectiveSliders() {
   );
 }
 
-function TransformControls() {
-  const { imageScale, setImageScale, perspective3D } = useImageStore();
-  const [controlMode, setControlMode] = React.useState<ControlMode>('zoom');
+function ZoomSlider() {
+  const imageScale = useImageStore((s) => s.imageScale);
+  const setImageScale = useImageStore((s) => s.setImageScale);
 
-  const zoomPercent = Math.round(imageScale);
+  return (
+    <Slider
+      value={[imageScale / 100]}
+      onValueChange={(value) => setImageScale(Math.round(value[0] * 100))}
+      min={0.1}
+      max={2}
+      step={0.01}
+      label="Zoom"
+      valueDisplay={`${Math.round(imageScale)}%`}
+    />
+  );
+}
+
+function TransformControls() {
+  const perspective3D = useImageStore((s) => s.perspective3D);
+  const setPerspective3D = useImageStore((s) => s.setPerspective3D);
+  const [controlMode, setControlMode] = React.useState<ControlMode>('zoom');
 
   return (
     <div className="space-y-3">
@@ -369,21 +385,11 @@ function TransformControls() {
 
       {/* Primary slider based on mode */}
       {controlMode === 'zoom' ? (
-        <Slider
-          value={[imageScale / 100]}
-          onValueChange={(value) => setImageScale(Math.round(value[0] * 100))}
-          min={0.1}
-          max={2}
-          step={0.01}
-          label="Zoom"
-          valueDisplay={`${zoomPercent}%`}
-        />
+        <ZoomSlider />
       ) : (
         <Slider
           value={[perspective3D.rotateZ]}
-          onValueChange={(value) =>
-            useImageStore.getState().setPerspective3D({ rotateZ: value[0] })
-          }
+          onValueChange={(value) => setPerspective3D({ rotateZ: value[0] })}
           min={-45}
           max={45}
           step={1}

--- a/components/editor/sections/BorderSection.tsx
+++ b/components/editor/sections/BorderSection.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import * as React from 'react';
 import { useImageStore } from '@/lib/store';
 import { Slider } from '@/components/ui/slider';
 import { SectionWrapper } from './SectionWrapper';
@@ -36,8 +35,26 @@ function BorderPreview({ radius, selected }: { radius: number; selected: boolean
   );
 }
 
+function ScaleSlider() {
+  const imageScale = useImageStore((s) => s.imageScale);
+  const setImageScale = useImageStore((s) => s.setImageScale);
+
+  return (
+    <Slider
+      value={[imageScale / 100]}
+      onValueChange={(value) => setImageScale(Math.round(value[0] * 100))}
+      min={0.1}
+      max={2}
+      step={0.01}
+      label="Scale"
+      valueDisplay={(imageScale / 100).toFixed(1)}
+    />
+  );
+}
+
 export function BorderSection() {
-  const { borderRadius, setBorderRadius, imageScale, setImageScale } = useImageStore();
+  const borderRadius = useImageStore((s) => s.borderRadius);
+  const setBorderRadius = useImageStore((s) => s.setBorderRadius);
 
   return (
     <SectionWrapper title="Border" defaultOpen={true}>
@@ -75,15 +92,7 @@ export function BorderSection() {
           label="Radius"
           valueDisplay={borderRadius}
         />
-        <Slider
-          value={[imageScale / 100]}
-          onValueChange={(value) => setImageScale(Math.round(value[0] * 100))}
-          min={0.1}
-          max={2}
-          step={0.01}
-          label="Scale"
-          valueDisplay={(imageScale / 100).toFixed(1)}
-        />
+        <ScaleSlider />
       </div>
     </SectionWrapper>
   );


### PR DESCRIPTION
## Vid

Before:

https://github.com/user-attachments/assets/ac5c0b97-3f1c-4502-8c39-6ce9fb2952b3

After:


https://github.com/user-attachments/assets/5f56c69c-67c3-4a67-95ba-0c7f29d613fc



## What

Resizing the image on the canvas calls `setImageScale` on every `pointermove`, so `imageScale` updates ~60-120x/sec. Several sidebar/panel components read the store and re-rendered on every one of those updates — and since React re-renders flow downward, each one dragged its entire subtree along.

Scoped down to:
- `LeftEditPanel` / `ModeDropdown`
- `RightSettingsPanel` (the Zoom/Tilt `TransformControls`)
- `BorderSection`

## Why spreading from the store subscribes to everything

`const { a, b } = useImageStore()` calls the hook with **no selector**, which returns the whole state object. Zustand then re-renders the component on **any** state change — not just `a`/`b` — because it can only compare the snapshot it was given, and that snapshot is the entire store. So a component that merely *reads* `editorMode` still re-renders when an unrelated `imageScale` ticks.

A selector — `useImageStore((s) => s.editorMode)` — subscribes to just that slice, so the component only re-renders when that value actually changes.

## Why we wrote it like this

Two changes, working together:

1. **Narrow selectors** so each panel only subscribes to what it uses. The panels here don't read `imageScale` at all, so after this they don't re-render during a resize.

2. **Leaf slider components** (`ScaleSlider`, `ZoomSlider`) that own the `imageScale` subscription. The slider genuinely needs the live value, so *something* must re-render per frame — but a child re-rendering never re-renders its parent. Pushing the subscription to a leaf means the per-frame update is contained to the tiny slider instead of the whole section.

Net effect during a resize: only the scale slider re-renders; the panels and their other controls stay put.

🤖 Generated with [Claude Code](https://claude.com/claude-code)