### PR TITLE
feat: delete/backspace clears the selected main image

### DIFF
--- a/components/canvas/ClientCanvas.tsx
+++ b/components/canvas/ClientCanvas.tsx
@@ -241,12 +241,16 @@ function CanvasRenderer({ image }: { image: HTMLImageElement }) {
         target.tagName === 'TEXTAREA' ||
         target.isContentEditable;
 
-      // Delete overlay (only when not typing)
+      // Delete selected overlay or main image (only when not typing)
       if ((e.key === "Delete" || e.key === "Backspace") && !isTyping) {
         if (selectedOverlayId) {
           e.preventDefault();
           removeImageOverlay(selectedOverlayId);
           setSelectedOverlayId(null);
+        } else if (isMainImageSelected) {
+          e.preventDefault();
+          useImageStore.getState().clearImage();
+          setIsMainImageSelected(false);
         }
       }
 
@@ -264,7 +268,7 @@ function CanvasRenderer({ image }: { image: HTMLImageElement }) {
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [selectedOverlayId, removeImageOverlay]);
+  }, [selectedOverlayId, removeImageOverlay, isMainImageSelected]);
 
   // Get selected overlay for toolbar positioning
   const selectedOverlay = selectedOverlayId


### PR DESCRIPTION
Pressing Delete/Backspace now clears the main image when it's selected (and no overlay is selected), matching the existing overlay-delete shortcut. Guarded by the same `isTyping` check so it doesn't fire while editing text inputs.