### PR TITLE
Figma-style canvas rulers with selection highlight

### DIFF
--- a/components/canvas/CanvasRulers.tsx
+++ b/components/canvas/CanvasRulers.tsx
@@ -1,80 +1,145 @@
 'use client'
 
-import { memo } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type RefObject } from 'react'
 
 const RULER_SIZE = 20
 const TICK_COLOR = 'rgba(128,128,128,0.6)'
 const LABEL_COLOR = 'rgba(128,128,128,0.8)'
 const FONT = '9px/1 ui-monospace, monospace'
+const HIGHLIGHT_FILL = 'var(--primary)'
 
-interface RulerProps {
-  length: number
-  orientation: 'horizontal' | 'vertical'
-  majorEvery: number
+/** Bounding box of the selected element, in canvas pixels. */
+interface RulerHighlight {
+  x: number
+  y: number
+  width: number
+  height: number
 }
 
-function Ruler({ length, orientation, majorEvery }: RulerProps) {
-  const safeMajorEvery = Number.isFinite(majorEvery) && majorEvery > 0 ? majorEvery : 100
+/** Resolved geometry of the ruler relative to the center viewport. */
+interface Geometry {
+  /** Viewport (center section) box in screen coords. */
+  vpLeft: number
+  vpTop: number
+  vpWidth: number
+  vpHeight: number
+  /** Canvas origin (value 0) measured from the viewport's top-left, in screen px. */
+  originX: number
+  originY: number
+  /** Screen px per canvas px (1 unless the canvas is CSS-scaled). */
+  scale: number
+  /** Axis-aligned box (canvas px) of the selected element, or null. */
+  highlight: RulerHighlight | null
+}
+
+function sameGeometry(a: Geometry | null, b: Geometry): boolean {
+  return (
+    a != null &&
+    a.vpLeft === b.vpLeft &&
+    a.vpTop === b.vpTop &&
+    a.vpWidth === b.vpWidth &&
+    a.vpHeight === b.vpHeight &&
+    a.originX === b.originX &&
+    a.originY === b.originY &&
+    a.scale === b.scale &&
+    a.highlight?.x === b.highlight?.x &&
+    a.highlight?.y === b.highlight?.y &&
+    a.highlight?.width === b.highlight?.width &&
+    a.highlight?.height === b.highlight?.height
+  )
+}
+
+const FLOAT_EPS = 1e-6
+
+function isMajorValue(value: number, majorEvery: number): boolean {
+  const m = Math.abs(value % majorEvery)
+  return m < FLOAT_EPS || Math.abs(m - majorEvery) < FLOAT_EPS
+}
+
+interface RulerBarProps {
+  orientation: 'horizontal' | 'vertical'
+  /** Full length of the bar (viewport width or height) in screen px. */
+  length: number
+  /** Canvas origin offset along this axis, from the viewport edge, in screen px. */
+  origin: number
+  scale: number
+  majorEvery: number
+  /** Selected element extent along this axis, in canvas px (or null). */
+  highlightStart: number | null
+  highlightEnd: number | null
+}
+
+function RulerBar({ orientation, length, origin, scale, majorEvery, highlightStart, highlightEnd }: RulerBarProps) {
   const isHorizontal = orientation === 'horizontal'
   const width = isHorizontal ? length : RULER_SIZE
   const height = isHorizontal ? RULER_SIZE : length
-  const minorEvery = safeMajorEvery / 2
+
+  const safeMajor = Number.isFinite(majorEvery) && majorEvery > 0 ? majorEvery : 100
+  const minorEvery = safeMajor / 2
+
+  // Selection band mapped to screen px along this axis.
+  const hasHighlight = highlightStart != null && highlightEnd != null
+  const bandA = hasHighlight ? origin + highlightStart * scale : 0
+  const bandB = hasHighlight ? origin + highlightEnd * scale : 0
+  const bandMin = Math.min(bandA, bandB)
+  const bandSize = Math.abs(bandB - bandA)
 
   const ticks: React.ReactNode[] = []
 
-  for (let pos = 0; pos <= length; pos += minorEvery) {
-    const isMajor = pos % safeMajorEvery === 0
+  // Range of canvas-pixel values that fall within the visible viewport span.
+  const startValue = Math.floor(-origin / scale / minorEvery) * minorEvery
+  const endValue = Math.ceil((length - origin) / scale / minorEvery) * minorEvery
+
+  for (let value = startValue; value <= endValue + FLOAT_EPS; value += minorEvery) {
+    const pos = origin + value * scale
+    if (pos < -1 || pos > length + 1) continue
+
+    const isMajor = isMajorValue(value, safeMajor)
     const tickLen = isMajor ? 10 : 5
 
     if (isHorizontal) {
       ticks.push(
         <line
-          key={pos}
+          key={`t${value}`}
           x1={pos}
           y1={RULER_SIZE - tickLen}
           x2={pos}
           y2={RULER_SIZE}
           stroke={TICK_COLOR}
           strokeWidth={1}
-        />
+        />,
       )
-      if (isMajor && pos > 0) {
+      if (isMajor) {
         ticks.push(
-          <text
-            key={`l${pos}`}
-            x={pos + 2}
-            y={RULER_SIZE - 4}
-            fill={LABEL_COLOR}
-            style={{ font: FONT }}
-          >
-            {pos}
-          </text>
+          <text key={`l${value}`} x={pos + 2} y={RULER_SIZE - 4} fill={LABEL_COLOR} style={{ font: FONT }}>
+            {Math.round(value)}
+          </text>,
         )
       }
     } else {
       ticks.push(
         <line
-          key={pos}
+          key={`t${value}`}
           x1={RULER_SIZE - tickLen}
           y1={pos}
           x2={RULER_SIZE}
           y2={pos}
           stroke={TICK_COLOR}
           strokeWidth={1}
-        />
+        />,
       )
-      if (isMajor && pos > 0) {
+      if (isMajor) {
         ticks.push(
           <text
-            key={`l${pos}`}
+            key={`l${value}`}
             x={RULER_SIZE - 2}
             y={pos + 2}
             fill={LABEL_COLOR}
             style={{ font: FONT }}
             textAnchor="end"
           >
-            {pos}
-          </text>
+            {Math.round(value)}
+          </text>,
         )
       }
     }
@@ -86,23 +151,44 @@ function Ruler({ length, orientation, majorEvery }: RulerProps) {
       height={height}
       style={{
         position: 'absolute',
-        ...(isHorizontal
-          ? { top: -RULER_SIZE, left: 0 }
-          : { left: -RULER_SIZE, top: 0 }),
+        top: 0,
+        left: 0,
         display: 'block',
         pointerEvents: 'none',
         userSelect: 'none',
       }}
     >
       {/* Ruler background */}
-      <rect
-        x={0}
-        y={0}
-        width={width}
-        height={height}
-        fill="var(--card)"
-        opacity={0.92}
-      />
+      <rect x={0} y={0} width={width} height={height} fill="var(--card)" opacity={0.92} />
+      {/* Selection band — highlights where the selected element fits */}
+      {hasHighlight &&
+        (isHorizontal ? (
+          <>
+            <rect x={bandMin} y={0} width={bandSize} height={RULER_SIZE} fill={HIGHLIGHT_FILL} opacity={0.25} />
+            <line x1={bandMin} y1={0} x2={bandMin} y2={RULER_SIZE} stroke={HIGHLIGHT_FILL} strokeWidth={1} />
+            <line
+              x1={bandMin + bandSize}
+              y1={0}
+              x2={bandMin + bandSize}
+              y2={RULER_SIZE}
+              stroke={HIGHLIGHT_FILL}
+              strokeWidth={1}
+            />
+          </>
+        ) : (
+          <>
+            <rect x={0} y={bandMin} width={RULER_SIZE} height={bandSize} fill={HIGHLIGHT_FILL} opacity={0.25} />
+            <line x1={0} y1={bandMin} x2={RULER_SIZE} y2={bandMin} stroke={HIGHLIGHT_FILL} strokeWidth={1} />
+            <line
+              x1={0}
+              y1={bandMin + bandSize}
+              x2={RULER_SIZE}
+              y2={bandMin + bandSize}
+              stroke={HIGHLIGHT_FILL}
+              strokeWidth={1}
+            />
+          </>
+        ))}
       {/* Border on the canvas-facing edge */}
       {isHorizontal ? (
         <line x1={0} y1={RULER_SIZE} x2={width} y2={RULER_SIZE} stroke={TICK_COLOR} strokeWidth={0.5} />
@@ -115,30 +201,154 @@ function Ruler({ length, orientation, majorEvery }: RulerProps) {
 }
 
 interface CanvasRulersProps {
+  canvasRef: RefObject<HTMLDivElement | null>
   canvasW: number
-  canvasH: number
   majorEvery?: number
+  /**
+   * CSS selector for the currently selected element. Its rendered bounding box
+   * (after rotation/scale/flip) is measured and highlighted on the rulers.
+   */
+  selectedSelector?: string | null
 }
 
-export const CanvasRulers = memo(function CanvasRulers({ canvasW, canvasH, majorEvery = 100 }: CanvasRulersProps) {
+export function CanvasRulers({
+  canvasRef,
+  canvasW,
+  majorEvery = 100,
+  selectedSelector = null,
+}: CanvasRulersProps) {
+  const [geo, setGeo] = useState<Geometry | null>(null)
+  const rafRef = useRef<number | null>(null)
+
+  const measure = useCallback(() => {
+    const canvasEl = canvasRef.current
+    if (!canvasEl) return
+
+    const viewportEl = canvasEl.closest('[data-canvas-viewport]') as HTMLElement | null
+    if (!viewportEl) return
+
+    const vp = viewportEl.getBoundingClientRect()
+    const cv = canvasEl.getBoundingClientRect()
+    const scale = canvasW > 0 && cv.width > 0 ? cv.width / canvasW : 1
+
+    let highlight: RulerHighlight | null = null
+    if (selectedSelector) {
+      const el = viewportEl.querySelector(selectedSelector)
+      if (el) {
+        const r = el.getBoundingClientRect()
+        highlight = {
+          x: (r.left - cv.left) / scale,
+          y: (r.top - cv.top) / scale,
+          width: r.width / scale,
+          height: r.height / scale,
+        }
+      }
+    }
+
+    const next: Geometry = {
+      vpLeft: vp.left,
+      vpTop: vp.top,
+      vpWidth: vp.width,
+      vpHeight: vp.height,
+      originX: cv.left - vp.left,
+      originY: cv.top - vp.top,
+      scale,
+      highlight,
+    }
+    setGeo((prev) => (sameGeometry(prev, next) ? prev : next))
+  }, [canvasRef, canvasW, selectedSelector])
+
+  const scheduleMeasure = useCallback(() => {
+    if (rafRef.current != null) return
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = null
+      measure()
+    })
+  }, [measure])
+
+  useLayoutEffect(() => {
+    measure()
+    if (!selectedSelector) return
+    let raf = 0
+    const tick = () => {
+      measure()
+      raf = requestAnimationFrame(tick)
+    }
+    raf = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(raf)
+  }, [measure, selectedSelector])
+
+  useEffect(() => {
+    const canvasEl = canvasRef.current
+    const viewportEl = canvasEl?.closest('[data-canvas-viewport]') as HTMLElement | null
+
+    const ro = new ResizeObserver(scheduleMeasure)
+    if (viewportEl) ro.observe(viewportEl)
+
+    window.addEventListener('resize', scheduleMeasure)
+    window.addEventListener('scroll', scheduleMeasure, true)
+
+    return () => {
+      ro.disconnect()
+      window.removeEventListener('resize', scheduleMeasure)
+      window.removeEventListener('scroll', scheduleMeasure, true)
+      if (rafRef.current != null) cancelAnimationFrame(rafRef.current)
+    }
+  }, [canvasRef, scheduleMeasure])
+
+  if (!geo) return null
+
   return (
-    <>
+    <div
+      style={{
+        position: 'fixed',
+        left: geo.vpLeft,
+        top: geo.vpTop,
+        width: geo.vpWidth,
+        height: geo.vpHeight,
+        pointerEvents: 'none',
+        zIndex: 30,
+        overflow: 'hidden',
+      }}
+    >
+      {/* Horizontal ruler — full viewport width along the top edge */}
+      <div style={{ position: 'absolute', top: 0, left: 0, width: geo.vpWidth, height: RULER_SIZE }}>
+        <RulerBar
+          orientation="horizontal"
+          length={geo.vpWidth}
+          origin={geo.originX}
+          scale={geo.scale}
+          majorEvery={majorEvery}
+          highlightStart={geo.highlight ? geo.highlight.x : null}
+          highlightEnd={geo.highlight ? geo.highlight.x + geo.highlight.width : null}
+        />
+      </div>
+
+      {/* Vertical ruler — full viewport height along the left edge */}
+      <div style={{ position: 'absolute', top: 0, left: 0, width: RULER_SIZE, height: geo.vpHeight }}>
+        <RulerBar
+          orientation="vertical"
+          length={geo.vpHeight}
+          origin={geo.originY}
+          scale={geo.scale}
+          majorEvery={majorEvery}
+          highlightStart={geo.highlight ? geo.highlight.y : null}
+          highlightEnd={geo.highlight ? geo.highlight.y + geo.highlight.height : null}
+        />
+      </div>
+
       {/* Corner block */}
       <div
         style={{
           position: 'absolute',
-          top: -RULER_SIZE,
-          left: -RULER_SIZE,
+          top: 0,
+          left: 0,
           width: RULER_SIZE,
           height: RULER_SIZE,
           background: 'var(--card)',
           opacity: 0.92,
-          pointerEvents: 'none',
-          zIndex: 1,
         }}
       />
-      <Ruler length={canvasW} orientation="horizontal" majorEvery={majorEvery} />
-      <Ruler length={canvasH} orientation="vertical" majorEvery={majorEvery} />
-    </>
+    </div>
   )
-})
+}

--- a/components/canvas/ClientCanvas.tsx
+++ b/components/canvas/ClientCanvas.tsx
@@ -397,6 +397,13 @@ function CanvasRenderer({ image }: { image: HTMLImageElement }) {
 
   const showFrame = frame.enabled && frame.type !== "none";
 
+  let selectedSelector: string | null = null;
+  if (isMainImageSelected) {
+    selectedSelector = '[data-main-image-layer="true"]';
+  } else if (selectedOverlayId) {
+    selectedSelector = `[data-overlay-id="${CSS.escape(selectedOverlayId)}"]`;
+  }
+
   const has3DTransform =
     perspective3D.rotateX !== 0 ||
     perspective3D.rotateY !== 0 ||
@@ -434,9 +441,22 @@ function CanvasRenderer({ image }: { image: HTMLImageElement }) {
         padding: "0px",
       }}
     >
-      {/* Ruler wrapper — position:relative so rulers can be absolutely offset outside the canvas */}
-      <div style={{ position: 'relative', display: 'inline-block', lineHeight: 0, marginTop: 20, marginLeft: 20 }}>
-        {showRulers && <CanvasRulers canvasW={canvasW} canvasH={canvasH} majorEvery={rulerInterval} />}
+      <div
+        style={{
+          position: 'relative',
+          display: 'inline-block',
+          lineHeight: 0,
+          ...(showRulers ? { marginTop: 20, marginLeft: 20 } : {}),
+        }}
+      >
+        {showRulers && (
+          <CanvasRulers
+            canvasRef={canvasContainerRef}
+            canvasW={canvasW}
+            majorEvery={rulerInterval}
+            selectedSelector={selectedSelector}
+          />
+        )}
         <HTMLCanvasRenderer
           ref={canvasContainerRef}
           width={canvasW}

--- a/components/canvas/EditorCanvas.tsx
+++ b/components/canvas/EditorCanvas.tsx
@@ -100,7 +100,10 @@ export function EditorCanvas() {
           onOpenChange={setExportOpen}
         />
 
-        <div className="flex-1 flex items-center justify-center overflow-y-auto overflow-x-hidden p-3 sm:p-4 md:p-6">
+        <div
+          data-canvas-viewport
+          className="relative flex-1 flex items-center justify-center overflow-y-auto overflow-x-hidden p-3 sm:p-4 md:p-6"
+        >
           <ClientCanvas />
         </div>
 


### PR DESCRIPTION
## Image
<img width="1512" height="949" alt="Screenshot 2026-06-28 at 5 23 39 PM" src="https://github.com/user-attachments/assets/785826ac-8291-4225-980a-fbfb4c3186e4" />


## What

Reworks the canvas rulers into a Figma-style ruler and adds a selection highlight.

### Full-viewport ruler
- `CanvasRulers` is now a `position: fixed` overlay spanning the **entire center editor section** (top + left edges) instead of hugging the canvas frame.
- Value `0` aligns with the canvas origin; ticks and labels extend across the whole area, including the empty space around the canvas (negative values to the left/above).
- Geometry is measured live (`getBoundingClientRect`) and re-tracked on viewport resize, window resize, and scroll, so the scale stays glued to the canvas.

### Selection highlight
- Selecting the main image or an image overlay highlights the band it occupies on both rulers.
- The band is derived from the element's **rendered bounding box**, so it correctly reflects rotation, scale, and flips, and updates live while dragging/rotating.

## Notes
- Text-overlay selection isn't highlighted yet (images only).
- Adds `data-canvas-viewport` to the center section in `EditorCanvas` so the ruler can measure it.

## Test plan
- [ ] Toggle rulers on — scale spans the full editor area, `0` at the canvas edge.
- [ ] Change ruler interval (25/50/100/200) — tick density updates.
- [ ] Scroll/resize the editor — ticks stay aligned to the canvas.
- [ ] Select the image / an overlay — band appears on both rulers; rotate it and confirm the band tracks the rotated bounds.