### PR TITLE
fix(canvas): keep main image selection handles a constant size

### DIFF
--- a/components/canvas/html/HTMLMainImageLayer.tsx
+++ b/components/canvas/html/HTMLMainImageLayer.tsx
@@ -379,6 +379,8 @@ export function HTMLMainImageLayer({
   const left = centerX - framedW / 2;
   const top = centerY - framedH / 2;
 
+  const handleScale = screenshot.scale > 0 ? 1 / screenshot.scale : 1;
+
   const browserRadius = screenshot.radius;
 
   // Image border radius based on frame type
@@ -622,6 +624,7 @@ export function HTMLMainImageLayer({
                   cursor,
                   zIndex: 20,
                   pointerEvents: 'auto',
+                  transform: `scale(${handleScale})`,
                 }}
               />
             );
@@ -632,12 +635,12 @@ export function HTMLMainImageLayer({
             data-resize-handle="true"
             style={{
               position: 'absolute',
-              top: '-35px',
+              top: `${-35 * handleScale}px`,
               left: '50%',
               width: '1px',
-              height: '30px',
+              height: `${30 * handleScale}px`,
               backgroundColor: 'rgba(59, 130, 246, 0.5)',
-              transform: 'translateX(-0.5px)',
+              transform: `translateX(-0.5px) scaleX(${handleScale})`,
               pointerEvents: 'none',
               zIndex: 20,
             }}
@@ -650,9 +653,10 @@ export function HTMLMainImageLayer({
             title="Rotate"
             style={{
               position: 'absolute',
-              top: '-52px',
+              top: `${-52 * handleScale}px`,
               left: '50%',
-              transform: 'translateX(-50%)',
+              transform: `translateX(-50%) scale(${handleScale})`,
+              transformOrigin: 'top center',
               width: '22px',
               height: '22px',
               backgroundColor: 'white',
@@ -679,9 +683,10 @@ export function HTMLMainImageLayer({
             title="Remove image"
             style={{
               position: 'absolute',
-              top: '-52px',
+              top: `${-52 * handleScale}px`,
               left: '50%',
-              transform: 'translateX(calc(-50% + 30px))',
+              transform: `translateX(calc(-50% + ${30 * handleScale}px)) scale(${handleScale})`,
+              transformOrigin: 'top center',
               width: '22px',
               height: '22px',
               backgroundColor: 'white',


### PR DESCRIPTION
## Image
 
## Before
<img width="1624" height="1061" alt="Screenshot 2026-06-28 at 5 51 48 PM" src="https://github.com/user-attachments/assets/9b20ebd2-88f3-426e-81d9-da0900eb709e" />


## After
<img width="1624" height="1061" alt="Screenshot 2026-06-28 at 5 51 21 PM" src="https://github.com/user-attachments/assets/2587d25f-92cb-4202-9f71-6f2fa8cd41c9" />


## Problem

When the main image is scaled down, its selection controls — the 4 corner resize handles, the rotate handle, the connector line, and the remove (X) button — also shrank. They became hard to grab at small image sizes.

## Cause

All the selection chrome is rendered inside the container that has `transform: scale(${screenshot.scale})` applied, so the handles were scaled along with the image.

## Fix

Introduced a counter-scale factor (`1 / screenshot.scale`) and applied it to each control's size and offsets so they keep a constant on-screen size and constant gaps regardless of the image's scale:

- **Corner handles** — `scale(handleScale)` about their center, keeping them pinned to the corners.
- **Connector line** — offset/length scaled, plus `scaleX` to keep thickness/length constant.
- **Rotate handle & X button** — offsets scaled and `scale(handleScale)` with `transformOrigin: top center` so the SVG icons stay full size and gaps stay constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)