### PR TITLE
feat: take website screenshots in dark mode

### DIFF
--- a/app/api/screenshot/route.ts
+++ b/app/api/screenshot/route.ts
@@ -5,8 +5,14 @@ import { checkRateLimit } from '@/lib/rate-limit'
 export const maxDuration = 60
 
 const MICROLINK_API_URL = process.env.SCREENSHOT_API_URL || 'https://api.microlink.io'
+type DeviceType = 'desktop' | 'mobile'
+type ColorScheme = 'light' | 'dark'
 
-async function captureViaService(url: string, deviceType: 'desktop' | 'mobile' = 'desktop'): Promise<{ screenshot: string; strategy: string }> {
+async function captureViaService(
+  url: string,
+  deviceType: DeviceType = 'desktop',
+  colorScheme: ColorScheme = 'light'
+): Promise<{ screenshot: string; strategy: string }> {
   try {
     const viewport = deviceType === 'mobile'
       ? { width: '375', height: '667', isMobile: 'true' }
@@ -19,6 +25,7 @@ async function captureViaService(url: string, deviceType: 'desktop' | 'mobile' =
       'viewport.width': viewport.width,
       'viewport.height': viewport.height,
       'viewport.isMobile': viewport.isMobile,
+      colorScheme,
     })
 
     const metaResponse = await fetch(`${MICROLINK_API_URL}/?${params.toString()}`, {
@@ -105,7 +112,7 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json()
-    const { url, forceRefresh, deviceType = 'desktop' } = body
+    const { url, forceRefresh, deviceType = 'desktop', colorScheme = 'light' } = body
 
     if (!url || typeof url !== 'string') {
       return NextResponse.json(
@@ -114,9 +121,16 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    if (deviceType && !['desktop', 'mobile'].includes(deviceType)) {
+    if (!['desktop', 'mobile'].includes(deviceType)) {
       return NextResponse.json(
         { error: 'deviceType must be either "desktop" or "mobile"' },
+        { status: 400 }
+      )
+    }
+
+    if (!['light', 'dark'].includes(colorScheme)) {
+      return NextResponse.json(
+        { error: 'colorScheme must be either "light" or "dark"' },
         { status: 400 }
       )
     }
@@ -130,7 +144,7 @@ export async function POST(request: NextRequest) {
           { status: 400 }
         )
       }
-    } catch (error) {
+    } catch {
       return NextResponse.json(
         { error: 'Invalid URL format' },
         { status: 400 }
@@ -138,7 +152,7 @@ export async function POST(request: NextRequest) {
     }
 
     const normalizedUrl = normalizeUrl(validUrl.toString())
-    const cacheKey = `${normalizedUrl}:${deviceType}`
+    const cacheKey = `${normalizedUrl}:${deviceType}:${colorScheme}`
 
     if (forceRefresh) {
       try {
@@ -157,6 +171,7 @@ export async function POST(request: NextRequest) {
             url: normalizedUrl,
             cached: true,
             deviceType,
+            colorScheme,
           })
         }
       } catch (cacheError) {
@@ -164,7 +179,7 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    const { screenshot, strategy } = await captureViaService(normalizedUrl, deviceType)
+    const { screenshot, strategy } = await captureViaService(normalizedUrl, deviceType, colorScheme)
 
     try {
       await cacheScreenshot(cacheKey, screenshot)
@@ -178,6 +193,7 @@ export async function POST(request: NextRequest) {
       cached: false,
       strategy,
       deviceType,
+      colorScheme,
     })
   } catch (error) {
     console.error('Screenshot error:', error)

--- a/components/controls/CleanUploadState.tsx
+++ b/components/controls/CleanUploadState.tsx
@@ -8,14 +8,17 @@ import {
   Globe02Icon,
   Loading03Icon,
 } from 'hugeicons-react';
+import { Moon, Sun } from 'lucide-react';
 import { ALLOWED_IMAGE_TYPES, MAX_IMAGE_SIZE } from '@/lib/constants';
 import { useEditorStore, useImageStore } from '@/lib/store';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { SegmentedControl } from '@/components/ui/segmented-control';
 import { getBackgroundCSS } from '@/lib/constants/backgrounds';
 
 const TRANSITION_DURATION = 400; // ms
+type ColorScheme = 'light' | 'dark';
 
 function extractImageUrl(style: React.CSSProperties): string | null {
   const bg = style.backgroundImage;
@@ -38,6 +41,7 @@ export function CleanUploadState() {
   const [isDragActive, setIsDragActive] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
   const [screenshotUrl, setScreenshotUrl] = React.useState('');
+  const [colorScheme, setColorScheme] = React.useState<ColorScheme>('light');
   const [isCapturing, setIsCapturing] = React.useState(false);
 
   const { setScreenshot } = useEditorStore();
@@ -224,7 +228,7 @@ export function CleanUploadState() {
       const response = await fetch('/api/screenshot', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ url: finalUrl, deviceType: 'desktop' }),
+        body: JSON.stringify({ url: finalUrl, deviceType: 'desktop', colorScheme }),
       });
       const data = await response.json();
       if (!response.ok) throw new Error(data.error || 'Failed to capture screenshot');
@@ -239,7 +243,7 @@ export function CleanUploadState() {
       const byteArray = new Uint8Array(byteNumbers);
       const blob = new Blob([byteArray], { type: 'image/png' });
       const blobUrl = URL.createObjectURL(blob);
-      const file = new File([blob], 'screenshot.png', { type: 'image/png' });
+      const file = new File([blob], `screenshot-${colorScheme}.png`, { type: 'image/png' });
       setScreenshot({ src: blobUrl });
       setImage(file);
       setScreenshotUrl('');
@@ -341,8 +345,11 @@ export function CleanUploadState() {
               <div className="flex-1 h-px" style={{ background: 'rgba(255,255,255,0.15)' }} />
             </div>
             <div className="flex gap-1.5 w-full">
-              <div className="relative flex-1">
-                <Globe02Icon size={14} className="absolute left-2.5 top-1/2 -translate-y-1/2" style={{ color: 'rgba(255,255,255,0.45)' }} />
+              <div
+                className="relative flex flex-1 items-center rounded-lg pl-2.5 pr-1 transition-shadow focus-within:ring-1 focus-within:ring-white/25"
+                style={{ background: 'rgba(0,0,0,0.25)', border: '1px solid rgba(255,255,255,0.15)' }}
+              >
+                <Globe02Icon size={14} className="shrink-0" style={{ color: 'rgba(255,255,255,0.45)' }} />
                 <Input
                   type="url"
                   placeholder="Enter website URL..."
@@ -350,17 +357,25 @@ export function CleanUploadState() {
                   onChange={(e) => setScreenshotUrl(e.target.value)}
                   onKeyDown={(e) => e.key === 'Enter' && handleCaptureScreenshot()}
                   disabled={isCapturing}
-                  className="pl-8 h-9 text-xs rounded-lg"
-                  style={{
-                    background: 'rgba(0,0,0,0.25)',
-                    borderColor: 'rgba(255,255,255,0.15)',
-                    color: 'rgba(255,255,255,0.9)',
-                  }}
+                  className="h-9 flex-1 border-0 bg-transparent px-2 text-xs shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 dark:bg-transparent"
+                  style={{ color: 'rgba(255,255,255,0.9)' }}
+                />
+                <div className="h-4 w-px shrink-0 bg-white/10" />
+                <SegmentedControl
+                  size="sm"
+                  value={colorScheme}
+                  onChange={(value) => setColorScheme(value as ColorScheme)}
+                  className={cn('ml-1 shrink-0 border-0 bg-transparent dark:bg-transparent p-[2px]', isCapturing && 'pointer-events-none opacity-60')}
+                  indicatorClassName="bg-white/15 dark:bg-white/15"
+                  options={[
+                    { id: 'light', icon: <Sun className="h-3 w-3" />, ariaLabel: 'Light' },
+                    { id: 'dark', icon: <Moon className="h-3 w-3" />, ariaLabel: 'Dark' },
+                  ]}
                 />
               </div>
               <Button
                 onClick={handleCaptureScreenshot}
-                disabled={isCapturing || !screenshotUrl.trim()}
+                disabled={isCapturing}
                 size="sm"
                 className="h-9 px-3 rounded-lg transition-all duration-200"
                 style={{

--- a/components/controls/WebsiteScreenshotInput.tsx
+++ b/components/controls/WebsiteScreenshotInput.tsx
@@ -5,14 +5,24 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { SegmentedControl } from '@/components/ui/segmented-control'
 import { useEditorStore, useImageStore } from '@/lib/store'
+import { cn } from '@/lib/utils'
 import { Loading03Icon, Globe02Icon, ComputerIcon, SmartPhone01Icon } from 'hugeicons-react'
+import { Moon, Sun } from 'lucide-react'
 
 type DeviceType = 'desktop' | 'mobile'
+type ColorScheme = 'light' | 'dark'
+
+const DEVICE_OPTIONS = [
+  { id: 'desktop', label: 'Desktop', Icon: ComputerIcon },
+  { id: 'mobile', label: 'Mobile', Icon: SmartPhone01Icon },
+] as const
 
 export function WebsiteScreenshotInput() {
   const [url, setUrl] = React.useState('')
   const [deviceType, setDeviceType] = React.useState<DeviceType>('desktop')
+  const [colorScheme, setColorScheme] = React.useState<ColorScheme>('light')
   const [isLoading, setIsLoading] = React.useState(false)
   const [error, setError] = React.useState<string | null>(null)
   const { setScreenshot } = useEditorStore()
@@ -48,7 +58,7 @@ export function WebsiteScreenshotInput() {
       }
       
       return { valid: true, normalized }
-    } catch (error) {
+    } catch {
       return { valid: false, error: 'Please enter a valid URL (e.g., example.com or https://example.com)' }
     }
   }
@@ -77,7 +87,7 @@ export function WebsiteScreenshotInput() {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ url: finalUrl, deviceType }),
+        body: JSON.stringify({ url: finalUrl, deviceType, colorScheme }),
       })
 
       const data = await response.json()
@@ -122,7 +132,7 @@ export function WebsiteScreenshotInput() {
       const blobUrl = URL.createObjectURL(blob)
 
       // Create a File object from the blob
-      const file = new File([blob], 'screenshot.png', { type: 'image/png' })
+      const file = new File([blob], `screenshot-${colorScheme}.png`, { type: 'image/png' })
 
       // Update stores immediately
       setScreenshot({ src: blobUrl })
@@ -196,44 +206,53 @@ export function WebsiteScreenshotInput() {
             )}
           </Button>
         </div>
-        <div className="flex items-center gap-3">
-          <Label htmlFor="device-type" className="text-sm font-medium whitespace-nowrap">
-            Device Type:
-          </Label>
-          <Select value={deviceType} onValueChange={(value) => setDeviceType(value as DeviceType)} disabled={isLoading}>
-            <SelectTrigger id="device-type" className="w-[140px]">
-              <SelectValue>
-                {deviceType === 'desktop' ? (
-                  <span className="flex items-center gap-2">
-                    <ComputerIcon className="h-4 w-4" />
-                    Desktop
-                  </span>
-                ) : (
-                  <span className="flex items-center gap-2">
-                    <SmartPhone01Icon className="h-4 w-4" />
-                    Mobile
-                  </span>
-                )}
-              </SelectValue>
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="desktop">
-                <span className="flex items-center gap-2">
-                  <ComputerIcon className="h-4 w-4" />
-                  Desktop
-                </span>
-              </SelectItem>
-              <SelectItem value="mobile">
-                <span className="flex items-center gap-2">
-                  <SmartPhone01Icon className="h-4 w-4" />
-                  Mobile
-                </span>
-              </SelectItem>
-            </SelectContent>
-          </Select>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="flex items-center gap-3">
+            <Label htmlFor="device-type" className="text-sm font-medium whitespace-nowrap">
+              Device:
+            </Label>
+            <Select value={deviceType} onValueChange={(value) => setDeviceType(value as DeviceType)} disabled={isLoading}>
+              <SelectTrigger id="device-type" className="w-[140px]">
+                <SelectValue>
+                  {DEVICE_OPTIONS.filter((o) => o.id === deviceType).map(({ id, label, Icon }) => (
+                    <span key={id} className="flex items-center gap-2">
+                      <Icon className="h-4 w-4" />
+                      {label}
+                    </span>
+                  ))}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                {DEVICE_OPTIONS.map(({ id, label, Icon }) => (
+                  <SelectItem key={id} value={id}>
+                    <span className="flex items-center gap-2">
+                      <Icon className="h-4 w-4" />
+                      {label}
+                    </span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex items-center gap-3 sm:justify-end">
+            <Label className="text-sm font-medium whitespace-nowrap">
+              Theme:
+            </Label>
+            <SegmentedControl
+              size="sm"
+              value={colorScheme}
+              onChange={(value) => setColorScheme(value as ColorScheme)}
+              className={cn("w-[72px]", isLoading && "pointer-events-none opacity-60")}
+              options={[
+                { id: 'light', icon: <Sun className="h-3.5 w-3.5" />, ariaLabel: 'Light' },
+                { id: 'dark', icon: <Moon className="h-3.5 w-3.5" />, ariaLabel: 'Dark' },
+              ]}
+            />
+          </div>
         </div>
         <p className="text-xs text-muted-foreground">
-          Enter a website URL to capture a viewport screenshot. Choose desktop (1920x1080) or mobile (375x667) viewport size.
+          Enter a website URL to capture a viewport screenshot. Dark theme uses the site&apos;s prefers-color-scheme support.
         </p>
       </div>
 
@@ -257,4 +276,3 @@ export function WebsiteScreenshotInput() {
     </div>
   )
 }
-

--- a/components/controls/WebsiteScreenshotInput.tsx
+++ b/components/controls/WebsiteScreenshotInput.tsx
@@ -5,24 +5,14 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
-import { SegmentedControl } from '@/components/ui/segmented-control'
 import { useEditorStore, useImageStore } from '@/lib/store'
-import { cn } from '@/lib/utils'
 import { Loading03Icon, Globe02Icon, ComputerIcon, SmartPhone01Icon } from 'hugeicons-react'
-import { Moon, Sun } from 'lucide-react'
 
 type DeviceType = 'desktop' | 'mobile'
-type ColorScheme = 'light' | 'dark'
-
-const DEVICE_OPTIONS = [
-  { id: 'desktop', label: 'Desktop', Icon: ComputerIcon },
-  { id: 'mobile', label: 'Mobile', Icon: SmartPhone01Icon },
-] as const
 
 export function WebsiteScreenshotInput() {
   const [url, setUrl] = React.useState('')
   const [deviceType, setDeviceType] = React.useState<DeviceType>('desktop')
-  const [colorScheme, setColorScheme] = React.useState<ColorScheme>('light')
   const [isLoading, setIsLoading] = React.useState(false)
   const [error, setError] = React.useState<string | null>(null)
   const { setScreenshot } = useEditorStore()
@@ -58,7 +48,7 @@ export function WebsiteScreenshotInput() {
       }
       
       return { valid: true, normalized }
-    } catch {
+    } catch (error) {
       return { valid: false, error: 'Please enter a valid URL (e.g., example.com or https://example.com)' }
     }
   }
@@ -87,7 +77,7 @@ export function WebsiteScreenshotInput() {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ url: finalUrl, deviceType, colorScheme }),
+        body: JSON.stringify({ url: finalUrl, deviceType }),
       })
 
       const data = await response.json()
@@ -132,7 +122,7 @@ export function WebsiteScreenshotInput() {
       const blobUrl = URL.createObjectURL(blob)
 
       // Create a File object from the blob
-      const file = new File([blob], `screenshot-${colorScheme}.png`, { type: 'image/png' })
+      const file = new File([blob], 'screenshot.png', { type: 'image/png' })
 
       // Update stores immediately
       setScreenshot({ src: blobUrl })
@@ -206,53 +196,44 @@ export function WebsiteScreenshotInput() {
             )}
           </Button>
         </div>
-        <div className="grid gap-3 sm:grid-cols-2">
-          <div className="flex items-center gap-3">
-            <Label htmlFor="device-type" className="text-sm font-medium whitespace-nowrap">
-              Device:
-            </Label>
-            <Select value={deviceType} onValueChange={(value) => setDeviceType(value as DeviceType)} disabled={isLoading}>
-              <SelectTrigger id="device-type" className="w-[140px]">
-                <SelectValue>
-                  {DEVICE_OPTIONS.filter((o) => o.id === deviceType).map(({ id, label, Icon }) => (
-                    <span key={id} className="flex items-center gap-2">
-                      <Icon className="h-4 w-4" />
-                      {label}
-                    </span>
-                  ))}
-                </SelectValue>
-              </SelectTrigger>
-              <SelectContent>
-                {DEVICE_OPTIONS.map(({ id, label, Icon }) => (
-                  <SelectItem key={id} value={id}>
-                    <span className="flex items-center gap-2">
-                      <Icon className="h-4 w-4" />
-                      {label}
-                    </span>
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-
-          <div className="flex items-center gap-3 sm:justify-end">
-            <Label className="text-sm font-medium whitespace-nowrap">
-              Theme:
-            </Label>
-            <SegmentedControl
-              size="sm"
-              value={colorScheme}
-              onChange={(value) => setColorScheme(value as ColorScheme)}
-              className={cn("w-[72px]", isLoading && "pointer-events-none opacity-60")}
-              options={[
-                { id: 'light', icon: <Sun className="h-3.5 w-3.5" />, ariaLabel: 'Light' },
-                { id: 'dark', icon: <Moon className="h-3.5 w-3.5" />, ariaLabel: 'Dark' },
-              ]}
-            />
-          </div>
+        <div className="flex items-center gap-3">
+          <Label htmlFor="device-type" className="text-sm font-medium whitespace-nowrap">
+            Device Type:
+          </Label>
+          <Select value={deviceType} onValueChange={(value) => setDeviceType(value as DeviceType)} disabled={isLoading}>
+            <SelectTrigger id="device-type" className="w-[140px]">
+              <SelectValue>
+                {deviceType === 'desktop' ? (
+                  <span className="flex items-center gap-2">
+                    <ComputerIcon className="h-4 w-4" />
+                    Desktop
+                  </span>
+                ) : (
+                  <span className="flex items-center gap-2">
+                    <SmartPhone01Icon className="h-4 w-4" />
+                    Mobile
+                  </span>
+                )}
+              </SelectValue>
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="desktop">
+                <span className="flex items-center gap-2">
+                  <ComputerIcon className="h-4 w-4" />
+                  Desktop
+                </span>
+              </SelectItem>
+              <SelectItem value="mobile">
+                <span className="flex items-center gap-2">
+                  <SmartPhone01Icon className="h-4 w-4" />
+                  Mobile
+                </span>
+              </SelectItem>
+            </SelectContent>
+          </Select>
         </div>
         <p className="text-xs text-muted-foreground">
-          Enter a website URL to capture a viewport screenshot. Dark theme uses the site&apos;s prefers-color-scheme support.
+          Enter a website URL to capture a viewport screenshot. Choose desktop (1920x1080) or mobile (375x667) viewport size.
         </p>
       </div>
 
@@ -276,3 +257,4 @@ export function WebsiteScreenshotInput() {
     </div>
   )
 }
+

--- a/components/ui/segmented-control.tsx
+++ b/components/ui/segmented-control.tsx
@@ -7,6 +7,7 @@ interface SegmentedControlOption {
   id: string;
   label?: string;
   icon?: React.ReactNode;
+  ariaLabel?: string;
 }
 
 interface SegmentedControlProps {
@@ -14,6 +15,7 @@ interface SegmentedControlProps {
   value: string;
   onChange: (value: string) => void;
   className?: string;
+  indicatorClassName?: string;
   size?: 'sm' | 'md';
 }
 
@@ -22,6 +24,7 @@ export function SegmentedControl({
   value,
   onChange,
   className,
+  indicatorClassName,
   size = 'md',
 }: SegmentedControlProps) {
   const activeIndex = options.findIndex((o) => o.id === value);
@@ -39,7 +42,8 @@ export function SegmentedControl({
           'absolute bg-background dark:bg-accent transition-all duration-200 ease-out',
           size === 'sm'
             ? 'top-[2px] bottom-[2px] rounded-[8px]'
-            : 'top-0.5 bottom-0.5 rounded-[10px]'
+            : 'top-0.5 bottom-0.5 rounded-[10px]',
+          indicatorClassName
         )}
         style={{
           left: `calc(${activeIndex * (100 / options.length)}% + 2px)`,
@@ -49,7 +53,10 @@ export function SegmentedControl({
       {options.map((option) => (
         <button
           key={option.id}
+          type="button"
           onClick={() => onChange(option.id)}
+          aria-label={option.ariaLabel ?? option.label}
+          title={option.ariaLabel ?? option.label}
           className={cn(
             'relative z-10 flex-1 flex items-center justify-center gap-1.5 transition-colors duration-150',
             size === 'sm'


### PR DESCRIPTION
## Summary
- add a light/dark color scheme option to website screenshot capture controls
- pass colorScheme through the screenshot API and Microlink request
- include colorScheme in screenshot cache keys and responses

Closes #68

## Verification
- npx eslint app/api/screenshot/route.ts components/controls/CleanUploadState.tsx components/controls/WebsiteScreenshotInput.tsx components/ui/segmented-control.tsx

Note: npm run lint still fails on pre-existing repo-wide lint errors outside this change.