### PR TITLE
Fix progress bar jumping to ~50% instantly by removing double-scaled …

### DIFF
--- a/lib/export-slideshow-video.ts
+++ b/lib/export-slideshow-video.ts
@@ -226,7 +226,8 @@ async function exportSlideshowWithWebCodecs(
           await new Promise((r) => setTimeout(r, 0));
         }
       },
-      (p) => progress.set(40 + p * 0.55),
+
+      (p) => progress.set(p * 0.9),
       signal
     );
 
@@ -561,7 +562,7 @@ async function exportAnimationWithWebCodecs(
           await new Promise((r) => setTimeout(r, 0));
         }
       },
-      (p) => progress.set(50 + p * 0.5),
+      (p) => progress.set(p * 0.9),
       signal
     );
 

--- a/lib/export/ffmpeg-encoder.ts
+++ b/lib/export/ffmpeg-encoder.ts
@@ -341,9 +341,8 @@ export class FFmpegVideoEncoder {
       throw new Error(`Unsupported format: ${format}`);
     }
 
-    // Set up progress tracking for encoding (with tracked handler for cleanup)
     this.progressHandler = ({ progress }) => {
-      onProgress(40 + progress * 60);
+      onProgress(10 + progress * 90);
     };
     this.ffmpeg.on('progress', this.progressHandler);
 


### PR DESCRIPTION
…and artificial baseline offsets in export progress reporting